### PR TITLE
TLS using OpenSSL

### DIFF
--- a/examples/http-benchmark.cpp
+++ b/examples/http-benchmark.cpp
@@ -32,7 +32,6 @@ namespace {
                      ward, fd, buffer)) {
             /// The headers should really be processed
         }
-        /// TODO Send response
         co_await write_all(ward, fd, response);
         co_await ward.close(std::move(fd));
         co_return;
@@ -55,9 +54,7 @@ namespace {
     }
 
 
-    /**
-     * ## Main
-     */
+    /// ## Main
     felspar::io::warden::task<int> co_main(felspar::io::warden &ward) {
         constexpr std::uint16_t port{4040};
         constexpr int backlog = 64;

--- a/include/felspar/io/read.hpp
+++ b/include/felspar/io/read.hpp
@@ -41,14 +41,14 @@ namespace felspar::io {
         read_buffer() {}
 
         template<typename S>
-        warden::task<void> read_some(
+        warden::task<void> do_read_some(
                 warden &ward,
                 S &&sock,
                 std::optional<std::chrono::nanoseconds> timeout = {},
                 felspar::source_location const &loc =
                         felspar::source_location::current()) {
             std::size_t const bytes_read =
-                    co_await ward.read_some(sock, remaining(), timeout, loc);
+                    co_await read_some(ward, sock, remaining(), timeout, loc);
             if (bytes_read == 0) {
                 throw stdexcept::runtime_error{
                         "Got a zero read, we're done", loc};
@@ -137,7 +137,7 @@ namespace felspar::io {
                     felspar::source_location::current()) {
         auto cr = read_buffer.find('\n');
         while (cr == read_buffer.end()) {
-            co_await read_buffer.read_some(ward, sock, timeout, loc);
+            co_await read_buffer.do_read_some(ward, sock, timeout, loc);
             cr = read_buffer.find('\n');
         }
         std::size_t const line = std::distance(read_buffer.begin(), cr);

--- a/include/felspar/io/read.hpp
+++ b/include/felspar/io/read.hpp
@@ -12,14 +12,15 @@ namespace felspar::io {
 
 
     /// Free standing version of `read_some`
-    template<typename S>
+    template<typename S, typename B>
     inline auto read_some(
             io::warden &warden,
             S &&sock,
+            B &&buffer,
             std::optional<std::chrono::nanoseconds> const timeout = {},
             felspar::source_location const &loc =
                     felspar::source_location::current()) {
-        return warden.read_some(sock, timeout, loc);
+        return warden.read_some(sock, buffer, timeout, loc);
     }
 
 

--- a/include/felspar/io/read.hpp
+++ b/include/felspar/io/read.hpp
@@ -11,6 +11,18 @@
 namespace felspar::io {
 
 
+    /// Free standing version of `read_some`
+    template<typename S>
+    inline auto read_some(
+            io::warden &warden,
+            S &&sock,
+            std::optional<std::chrono::nanoseconds> const timeout = {},
+            felspar::source_location const &loc =
+                    felspar::source_location::current()) {
+        return warden.read_some(sock, timeout, loc);
+    }
+
+
     /// A read buffer that can be split up and have more information read into
     /// it over time as data appears on the file descriptor
     template<typename R>

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -38,14 +38,14 @@ namespace felspar::io {
                 warden &w,
                 std::span<std::byte>,
                 std::optional<std::chrono::nanoseconds> const timeout = {},
-                felspar::source_location const &loc =
+                felspar::source_location const & =
                         felspar::source_location::current());
         /// Write to the connection
         warden::task<std::size_t> write_some(
                 warden &w,
                 std::span<std::byte const>,
                 std::optional<std::chrono::nanoseconds> const timeout = {},
-                felspar::source_location const &loc =
+                felspar::source_location const & =
                         felspar::source_location::current());
     };
 

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -26,6 +26,7 @@ namespace felspar::io {
         /// ### Connect to a TLS secured server over TCP
         static warden::task<tls>
                 connect(warden &,
+                        char const *snI_hostname,
                         sockaddr const *addr,
                         socklen_t addrlen,
                         std::optional<std::chrono::nanoseconds> timeout = {},

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -32,6 +32,13 @@ namespace felspar::io {
                         felspar::source_location const & =
                                 felspar::source_location::current());
 
+        /// Read from the connection
+        warden::task<std::size_t> read_some(
+                warden &w,
+                std::span<std::byte>,
+                std::optional<std::chrono::nanoseconds> const timeout = {},
+                felspar::source_location const &loc =
+                        felspar::source_location::current());
         /// Write to the connection
         warden::task<std::size_t> write_some(
                 warden &w,
@@ -43,6 +50,16 @@ namespace felspar::io {
 
 
     /// ## Free-standing APIs
+
+    inline auto read_some(
+            warden &w,
+            tls &cnx,
+            std::span<std::byte> const s,
+            std::optional<std::chrono::nanoseconds> const timeout = {},
+            felspar::source_location const &loc =
+                    felspar::source_location::current()) {
+        return cnx.read_some(w, s, timeout, loc);
+    }
     inline auto write_some(
             warden &w,
             tls &cnx,

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -12,6 +12,8 @@ namespace felspar::io {
         struct impl;
         std::unique_ptr<impl> p;
 
+        explicit tls(std::unique_ptr<impl>);
+
       public:
         tls();
         tls(tls const &) = delete;

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -31,7 +31,27 @@ namespace felspar::io {
                         std::optional<std::chrono::nanoseconds> timeout = {},
                         felspar::source_location const & =
                                 felspar::source_location::current());
+
+        /// Write to the connection
+        warden::task<std::size_t> write_some(
+                warden &w,
+                std::span<std::byte const>,
+                std::optional<std::chrono::nanoseconds> const timeout = {},
+                felspar::source_location const &loc =
+                        felspar::source_location::current());
     };
+
+
+    /// ## Free-standing APIs
+    inline auto write_some(
+            warden &w,
+            tls &cnx,
+            std::span<std::byte const> const s,
+            std::optional<std::chrono::nanoseconds> const timeout = {},
+            felspar::source_location const &loc =
+                    felspar::source_location::current()) {
+        return cnx.write_some(w, s, timeout, loc);
+    }
 
 
 }

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+
+#include <felspar/io/warden.hpp>
+
+
+namespace felspar::io {
+
+
+    /// ## TLS secured TCP connection
+    class tls final {
+        struct impl;
+        std::unique_ptr<impl> p;
+
+      public:
+        tls();
+        tls(tls const &) = delete;
+        tls(tls &&);
+        ~tls();
+
+        tls &operator=(tls const &) = delete;
+        tls &operator=(tls &&);
+
+        /// ### Connect to a TLS secured server over TCP
+        static warden::task<tls>
+                connect(warden &,
+                        sockaddr const *addr,
+                        socklen_t addrlen,
+                        std::optional<std::chrono::nanoseconds> timeout = {},
+                        felspar::source_location const & =
+                                felspar::source_location::current());
+    };
+
+
+}

--- a/include/felspar/io/write.hpp
+++ b/include/felspar/io/write.hpp
@@ -13,7 +13,20 @@ namespace felspar::io {
     class warden;
 
 
-    /// Write all of the buffer to a file descriptor
+    /// ## Free standing version of `write_some`
+    template<typename S>
+    inline auto write_some(
+            warden &w,
+            S &&sock,
+            std::span<std::byte const> const s,
+            std::optional<std::chrono::nanoseconds> const timeout = {},
+            felspar::source_location const &loc =
+                    felspar::source_location::current()) {
+        return w.write_some(sock, s, timeout, loc);
+    }
+
+
+    /// ## Write all of the buffer to a file descriptor
     template<typename S>
     inline warden::task<std::size_t> write_all(
             warden &ward,
@@ -25,7 +38,7 @@ namespace felspar::io {
         auto out{s};
         while (out.size()) {
             auto const bytes =
-                    co_await ward.write_some(sock, out, timeout, loc);
+                    co_await write_some(ward, sock, out, timeout, loc);
             if (not bytes) { co_return s.size() - out.size(); }
             out = out.subspan(bytes);
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,10 +3,11 @@ add_library(felspar-io
         poll.iops.cpp
         poll.warden.cpp
         posix.cpp
+        tls.cpp
         warden.cpp
     )
 target_include_directories(felspar-io PUBLIC ../include)
-target_link_libraries(felspar-io PUBLIC felspar-coro)
+target_link_libraries(felspar-io PUBLIC felspar-coro ssl)
 if(${FELSPAR_ENABLE_IO_URING})
     target_compile_definitions(felspar-io PUBLIC FELSPAR_ENABLE_IO_URING=1)
     target_sources(felspar-io PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,11 +3,14 @@ add_library(felspar-io
         poll.iops.cpp
         poll.warden.cpp
         posix.cpp
-        tls.cpp
         warden.cpp
     )
 target_include_directories(felspar-io PUBLIC ../include)
-target_link_libraries(felspar-io PUBLIC felspar-coro ssl)
+target_link_libraries(felspar-io PUBLIC felspar-coro)
+add_library(felspar-io-openssl
+        tls.cpp
+    )
+target_link_libraries(felspar-io-openssl felspar-io ssl crypto)
 if(${FELSPAR_ENABLE_IO_URING})
     target_compile_definitions(felspar-io PUBLIC FELSPAR_ENABLE_IO_URING=1)
     target_sources(felspar-io PRIVATE
@@ -24,4 +27,5 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif()
 
 install(TARGETS felspar-io LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+install(TARGETS felspar-io-openssl LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 install(DIRECTORY ../include/felspar DESTINATION include)

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -1,0 +1,44 @@
+#include <felspar/io/tls.hpp>
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+
+/// ## `felspar::io::tls::impl`
+
+
+struct felspar::io::tls::impl {
+    impl() : ctx{SSL_CTX_new(TLS_method())}, ssl{SSL_new(ctx)} {}
+    ~impl() {
+        if (ssl) { SSL_free(ssl); }
+        if (ctx) { SSL_CTX_free(ctx); }
+    }
+    SSL_CTX *ctx = nullptr;
+    SSL *ssl = nullptr;
+    BIO *ib = nullptr, *nb = nullptr;
+    posix::fd fd;
+};
+
+
+/// ## `felspar::io::tls`
+
+
+felspar::io::tls::tls() = default;
+felspar::io::tls::tls(tls &&) = default;
+felspar::io::tls::~tls() = default;
+felspar::io::tls &felspar::io::tls::operator=(tls &&) = default;
+
+
+auto felspar::io::tls::connect(
+        io::warden &warden,
+        sockaddr const *addr,
+        socklen_t addrlen,
+        std::optional<std::chrono::nanoseconds> timeout,
+        felspar::source_location const &loc) -> warden::task<tls> {
+    posix::fd fd = warden.create_socket(AF_INET, SOCK_STREAM, 0);
+    co_await warden.connect(fd, addr, addrlen, timeout, loc);
+
+    auto i = std::make_unique<impl>();
+
+    co_return {};
+}

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -8,13 +8,20 @@
 
 
 struct felspar::io::tls::impl {
-    impl() : ctx{SSL_CTX_new(TLS_method())}, ssl{SSL_new(ctx)} {}
+    impl() : ctx{SSL_CTX_new(TLS_method())}, ssl{SSL_new(ctx)} {
+        /// TODO There should be some error handling here
+        BIO_new_bio_pair(&ib, 0, &nb, 0);
+        /// Give the internal BIO to `ssl`
+        SSL_set_bio(ssl, ib, ib);
+    }
     ~impl() {
+        if (nb) { BIO_free(nb); }
         if (ssl) { SSL_free(ssl); }
         if (ctx) { SSL_CTX_free(ctx); }
     }
     SSL_CTX *ctx = nullptr;
     SSL *ssl = nullptr;
+    /// `ib` is the internal BIO and `nb` is the network BIO
     BIO *ib = nullptr, *nb = nullptr;
     posix::fd fd;
 };

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -120,6 +120,7 @@ felspar::io::tls::tls(std::unique_ptr<impl> i) : p{std::move(i)} {}
 
 auto felspar::io::tls::connect(
         io::warden &warden,
+        char const *const sni_hostname,
         sockaddr const *addr,
         socklen_t addrlen,
         std::optional<std::chrono::nanoseconds> timeout,
@@ -128,6 +129,7 @@ auto felspar::io::tls::connect(
     co_await warden.connect(fd, addr, addrlen, timeout, loc);
 
     auto i = std::make_unique<impl>(std::move(fd));
+    SSL_set_tlsext_host_name(i->ssl, sni_hostname);
     co_await i->service_operation(
             warden, timeout, loc, [](impl &i) { return SSL_connect(i.ssl); });
 

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -1,4 +1,5 @@
 #include <felspar/io/tls.hpp>
+#include <felspar/io/write.hpp>
 
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -8,7 +9,8 @@
 
 
 struct felspar::io::tls::impl {
-    impl() : ctx{SSL_CTX_new(TLS_method())}, ssl{SSL_new(ctx)} {
+    impl(posix::fd f)
+    : ctx{SSL_CTX_new(TLS_method())}, ssl{SSL_new(ctx)}, fd{std::move(f)} {
         /// TODO There should be some error handling here
         BIO_new_bio_pair(&ib, 0, &nb, 0);
         /// Give the internal BIO to `ssl`
@@ -24,6 +26,79 @@ struct felspar::io::tls::impl {
     /// `ib` is the internal BIO and `nb` is the network BIO
     BIO *ib = nullptr, *nb = nullptr;
     posix::fd fd;
+
+    /**
+     * A data buffer that we'll use whilst sending/receiving data. The TLS
+     * record size is 16KB so we make this just a little bit bigger.
+     */
+    std::array<std::byte, (17 << 10)> buffer;
+
+    /// openssl operations
+    int do_connect() { return SSL_connect(ssl); }
+
+    /// Loop for handling read/write requests when trying to carry out an operation
+    io::warden::task<int> service_operation(
+            io::warden &warden,
+            int (impl::*op)(void),
+            std::optional<std::chrono::nanoseconds> timeout,
+            felspar::source_location const &loc) {
+        while (true) {
+            auto const result = (this->*op)();
+            auto const error = SSL_get_error(ssl, result);
+            switch (error) {
+            case SSL_ERROR_NONE: co_return result;
+
+            case SSL_ERROR_WANT_READ:
+                co_await bio_read(warden, timeout, loc);
+                [[fallthrough]];
+            case SSL_ERROR_WANT_WRITE:
+                co_await bio_write(warden, timeout, loc);
+                break;
+
+            default:
+                throw felspar::stdexcept::runtime_error{
+                        "Unknown openssl error " + std::to_string(error), loc};
+            }
+        }
+    }
+
+    io::warden::task<void> bio_read(
+            io::warden &warden,
+            std::optional<std::chrono::nanoseconds> timeout,
+            felspar::source_location const &loc) {
+        if (auto bytes = BIO_ctrl_pending(nb); bytes > buffer.size()) {
+            throw felspar::stdexcept::logic_error{
+                    "Pending read BIO buffer too small"};
+        } else if (bytes) {
+            if (auto const read_int = BIO_read(nb, buffer.data(), bytes);
+                read_int <= 0) {
+                throw felspar::stdexcept::runtime_error{
+                        "Error reading from BIO"};
+            } else if (auto const read_bytes = read_int; read_bytes != bytes) {
+                throw felspar::stdexcept::runtime_error{
+                        "Reading BIO read bytes mismatch"};
+            } else {
+                co_await felspar::io::write_all(
+                        warden, fd, buffer.data(), bytes, timeout, loc);
+            }
+        }
+    }
+    io::warden::task<std::size_t> bio_write(
+            io::warden &warden,
+            std::optional<std::chrono::nanoseconds> timeout,
+            felspar::source_location const &loc) {
+        auto const bytes = co_await warden.read_some(fd, buffer, timeout, loc);
+        if (auto const written_int = BIO_write(nb, buffer.data(), bytes);
+            written_int <= 0) {
+            throw felspar::stdexcept::runtime_error{"Error writing to BIO"};
+        } else if (auto const written_bytes = written_int;
+                   written_bytes != bytes) {
+            throw felspar::stdexcept::runtime_error{
+                    "Not all bytes written to BIO"};
+        } else {
+            co_return written_bytes;
+        }
+    }
 };
 
 
@@ -35,6 +110,8 @@ felspar::io::tls::tls(tls &&) = default;
 felspar::io::tls::~tls() = default;
 felspar::io::tls &felspar::io::tls::operator=(tls &&) = default;
 
+felspar::io::tls::tls(std::unique_ptr<impl> i) : p{std::move(i)} {}
+
 
 auto felspar::io::tls::connect(
         io::warden &warden,
@@ -45,7 +122,8 @@ auto felspar::io::tls::connect(
     posix::fd fd = warden.create_socket(AF_INET, SOCK_STREAM, 0);
     co_await warden.connect(fd, addr, addrlen, timeout, loc);
 
-    auto i = std::make_unique<impl>();
+    auto i = std::make_unique<impl>(std::move(fd));
+    co_await i->service_operation(warden, &impl::do_connect, timeout, loc);
 
-    co_return {};
+    co_return tls{std::move(i)};
 }

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(felspar-io-headers-tests STATIC EXCLUDE_FROM_ALL
         io.cpp
         posix.cpp
         read.cpp
+        tls.cpp
         warden.cpp
         warden.poll.cpp
         write.cpp

--- a/test/headers/tls.cpp
+++ b/test/headers/tls.cpp
@@ -1,0 +1,1 @@
+#include <felspar/io/tls.hpp>

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -8,7 +8,7 @@ if(TARGET felspar-check)
         )
 endif()
 if(TARGET felspar-stress)
-    add_test_run(felspar-stress felspar-io TESTS
+    add_test_run(felspar-stress felspar-io-openssl TESTS
             timers.connect.cpp
             tls.tests.cpp
         )

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -10,5 +10,6 @@ endif()
 if(TARGET felspar-stress)
     add_test_run(felspar-stress felspar-io TESTS
             timers.connect.cpp
+            tls.tests.cpp
         )
 endif()

--- a/test/run/timers.cpp
+++ b/test/run/timers.cpp
@@ -56,7 +56,7 @@ namespace {
         co_await ward.connect(
                 fd, reinterpret_cast<sockaddr const *>(&in), sizeof(in));
         try {
-            while (co_await ward.write_some(fd, buffer, 10ms))
+            while (co_await felspar::io::write_some(ward, fd, buffer, 10ms))
                 ;
             check(false) == true;
         } catch (felspar::io::timeout const &) {
@@ -71,7 +71,7 @@ namespace {
 
         while (true) {
             auto const result{co_await felspar::io::ec{
-                    ward.write_some(fd, buffer, 10ms)}};
+                    felspar::io::write_some(ward, fd, buffer, 10ms)}};
             if (not result and result.error == felspar::io::timeout::error) {
                 co_return;
             } else if (not result) {

--- a/test/run/tls.tests.cpp
+++ b/test/run/tls.tests.cpp
@@ -35,7 +35,7 @@ namespace {
         freeaddrinfo(addresses);
 
         auto website = co_await felspar::io::tls::connect(
-                warden, reinterpret_cast<sockaddr const *>(&address),
+                warden, hostname, reinterpret_cast<sockaddr const *>(&address),
                 sizeof(address), 5s);
 
         auto written =

--- a/test/run/tls.tests.cpp
+++ b/test/run/tls.tests.cpp
@@ -1,5 +1,6 @@
 #include <felspar/io/tls.hpp>
 #include <felspar/io/warden.poll.hpp>
+#include <felspar/io/write.hpp>
 #include <felspar/test.hpp>
 
 #include <sys/types.h>
@@ -36,6 +37,10 @@ namespace {
         auto website = co_await felspar::io::tls::connect(
                 warden, reinterpret_cast<sockaddr const *>(&address),
                 sizeof(address), 5s);
+
+        auto written =
+                co_await felspar::io::write_all(warden, website, "Hello\r\n");
+        check(written) == 7u;
     }
 
 

--- a/test/run/tls.tests.cpp
+++ b/test/run/tls.tests.cpp
@@ -41,6 +41,15 @@ namespace {
         auto written =
                 co_await felspar::io::write_all(warden, website, "Hello\r\n");
         check(written) == 7u;
+
+        std::array<std::byte, 4> buffer;
+        auto read = co_await felspar::io::read_some(warden, website, buffer);
+        check(read) == 4;
+
+        check(buffer[0]) == std::byte{'H'};
+        check(buffer[1]) == std::byte{'T'};
+        check(buffer[2]) == std::byte{'T'};
+        check(buffer[3]) == std::byte{'P'};
     }
 
 

--- a/test/run/tls.tests.cpp
+++ b/test/run/tls.tests.cpp
@@ -1,0 +1,48 @@
+#include <felspar/io/tls.hpp>
+#include <felspar/io/warden.poll.hpp>
+#include <felspar/test.hpp>
+
+#include <sys/types.h>
+#if defined(FELSPAR_POSIX_SOCKETS)
+#include <sys/socket.h>
+#include <netdb.h>
+#endif
+
+
+using namespace std::literals;
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("tls");
+
+
+    felspar::io::warden::task<void> test_connect(
+            felspar::io::warden &warden,
+            char const *const hostname,
+            felspar::test::injected check) {
+        struct addrinfo hints = {};
+        hints.ai_socktype = SOCK_STREAM;
+        struct addrinfo *addresses = nullptr;
+        check(getaddrinfo(hostname, nullptr, &hints, &addresses)) == 0;
+        check(addresses) != nullptr;
+
+        sockaddr_in address =
+                *reinterpret_cast<sockaddr_in *>(addresses->ai_addr);
+        address.sin_port = htons(443);
+        freeaddrinfo(addresses);
+
+        auto website = co_await felspar::io::tls::connect(
+                warden, reinterpret_cast<sockaddr const *>(&address),
+                sizeof(address), 5s);
+    }
+
+
+    auto const connect = suite.test("connect", [](auto check) {
+        felspar::io::poll_warden ward;
+        ward.run(test_connect, "felspar.com", check);
+    });
+
+
+}


### PR DESCRIPTION
This uses OpenSSL's BIO functionality to separate the encryption from the socket handling. This allows felspar-io to use its own non-blocking socket sends (for example, with io_uring on Linux) and still be able to make use of TLS.