### PR TITLE
Pipe for Windows

### DIFF
--- a/include/felspar/io.hpp
+++ b/include/felspar/io.hpp
@@ -6,6 +6,7 @@
 #include <felspar/io/connect.hpp>
 #include <felspar/io/error.hpp>
 #include <felspar/io/exceptions.hpp>
+#include <felspar/io/pipe.hpp>
 #include <felspar/io/posix.hpp>
 #include <felspar/io/read.hpp>
 #include <felspar/io/warden.poll.hpp>

--- a/include/felspar/io/pipe.hpp
+++ b/include/felspar/io/pipe.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+
+#include <felspar/io/posix.hpp>
+
+
+namespace felspar::io {
+
+
+    /// ## A pipe has a read and a write end
+    /**
+     * On true POSIX systems this will create a real pipe, but on Windows it
+     * will emulate a pipe using a pair of sockets.
+     */
+    struct pipe {
+        posix::fd read, write;
+    };
+
+
+}

--- a/include/felspar/io/posix.hpp
+++ b/include/felspar/io/posix.hpp
@@ -112,18 +112,18 @@ namespace felspar::posix {
 
 
     /// ## Bind
-    void bind(
-            io::socket_descriptor sock,
-            std::uint32_t addr,
-            std::uint16_t port,
-            felspar::source_location const & =
-                    felspar::source_location::current());
-    inline void bind(
-            fd const &sock,
-            std::uint32_t const addr,
-            std::uint16_t const port,
-            felspar::source_location const &loc =
-                    felspar::source_location::current()) {
+    void
+            bind(io::socket_descriptor sock,
+                 std::uint32_t addr,
+                 std::uint16_t port,
+                 felspar::source_location const & =
+                         felspar::source_location::current());
+    inline void
+            bind(fd const &sock,
+                 std::uint32_t const addr,
+                 std::uint16_t const port,
+                 felspar::source_location const &loc =
+                         felspar::source_location::current()) {
         return bind(sock.native_handle(), addr, port, loc);
     }
     inline void bind_to_any_address(
@@ -131,8 +131,8 @@ namespace felspar::posix {
             std::uint16_t port,
             felspar::source_location const &loc =
                     felspar::source_location::current()) {
-                        bind(sock, INADDR_ANY, port, loc);
-                    }
+        bind(sock, INADDR_ANY, port, loc);
+    }
     inline void bind_to_any_address(
             fd const &sock,
             std::uint16_t const port,

--- a/include/felspar/io/posix.hpp
+++ b/include/felspar/io/posix.hpp
@@ -111,18 +111,34 @@ namespace felspar::posix {
     }
 
 
-    /// ## Bind to any address
-    void bind_to_any_address(
+    /// ## Bind
+    void bind(
             io::socket_descriptor sock,
+            std::uint32_t addr,
             std::uint16_t port,
             felspar::source_location const & =
                     felspar::source_location::current());
+    inline void bind(
+            fd const &sock,
+            std::uint32_t const addr,
+            std::uint16_t const port,
+            felspar::source_location const &loc =
+                    felspar::source_location::current()) {
+        return bind(sock.native_handle(), addr, port, loc);
+    }
+    inline void bind_to_any_address(
+            io::socket_descriptor sock,
+            std::uint16_t port,
+            felspar::source_location const &loc =
+                    felspar::source_location::current()) {
+                        bind(sock, INADDR_ANY, port, loc);
+                    }
     inline void bind_to_any_address(
             fd const &sock,
             std::uint16_t const port,
             felspar::source_location const &loc =
                     felspar::source_location::current()) {
-        return bind_to_any_address(sock.native_handle(), port, loc);
+        return bind(sock.native_handle(), INADDR_ANY, port, loc);
     }
 
 

--- a/include/felspar/io/posix.hpp
+++ b/include/felspar/io/posix.hpp
@@ -16,14 +16,16 @@ namespace felspar::posix {
     class fd {
         io::socket_descriptor f;
 
+        static void close_socket_if_valid(io::socket_descriptor const s) {
+            if (s != io::invalid_handle) { ::close(s); }
+        }
+
       public:
         fd() : f{io::invalid_handle} {}
         explicit fd(io::socket_descriptor f) : f{f} {}
         fd(fd &&o) : f{std::exchange(o.f, io::invalid_handle)} {}
         fd(fd const &) = delete;
-        ~fd() {
-            if (f >= 0) { ::close(f); }
-        }
+        ~fd() { close_socket_if_valid(f); }
 
         fd &operator=(fd &&o) {
             fd s{std::exchange(f, std::exchange(o.f, io::invalid_handle))};
@@ -33,7 +35,9 @@ namespace felspar::posix {
 
 
         /// ### `true` if the file descriptor looks valid
-        explicit operator bool() const noexcept { return f >= 0; }
+        explicit operator bool() const noexcept {
+            return f != io::invalid_handle;
+        }
         io::socket_descriptor native_handle() const noexcept { return f; }
 
 
@@ -50,7 +54,7 @@ namespace felspar::posix {
          */
         void close() noexcept {
             io::socket_descriptor c = std::exchange(f, io::invalid_handle);
-            if (c >= 0) { ::close(c); }
+            close_socket_if_valid(c);
         }
     };
 

--- a/include/felspar/io/posix.hpp
+++ b/include/felspar/io/posix.hpp
@@ -59,18 +59,6 @@ namespace felspar::posix {
     };
 
 
-    /// ## A pipe has a read and a write end
-    struct pipe {
-        fd read, write;
-
-        /// ### Create a new pipe
-        /// The file descriptors will be set to non-blocking mode.
-        static pipe
-                create(felspar::source_location const & =
-                               felspar::source_location::current());
-    };
-
-
     /// ## `select` handling
     /**
      * Set the number of open file descriptors this process can use to the

--- a/include/felspar/io/posix.hpp
+++ b/include/felspar/io/posix.hpp
@@ -61,7 +61,9 @@ namespace felspar::posix {
 
         /// ### Create a new pipe
         /// The file descriptors will be set to non-blocking mode.
-        static pipe create();
+        static pipe
+                create(felspar::source_location const & =
+                               felspar::source_location::current());
     };
 
 

--- a/include/felspar/io/warden.hpp
+++ b/include/felspar/io/warden.hpp
@@ -3,6 +3,7 @@
 #include <felspar/coro/start.hpp>
 #include <felspar/coro/stream.hpp>
 #include <felspar/io/completion.hpp>
+#include <felspar/io/pipe.hpp>
 #include <felspar/io/posix.hpp>
 #include <felspar/memory/pmr.hpp>
 #include <felspar/test/source.hpp>
@@ -116,6 +117,8 @@ namespace felspar::io {
         }
 
         /// ### Socket APIs
+
+        /// #### Socket creation
         /**
          * Some wardens may need special socket options to be set, so in order
          * to be portable across wardens use this API instead of the POSIX
@@ -127,8 +130,13 @@ namespace felspar::io {
                 int protocol,
                 felspar::source_location const & =
                         felspar::source_location::current());
-        /// Create a pipe that has also had its end points wrapped by this warden.
-        posix::pipe create_pipe(
+
+        /// #### Pipe
+        /**
+         * Create a pipe usable by this warden. On Windows a true pipe will be
+         * simulated by a socket pair.
+         */
+        pipe create_pipe(
                 felspar::source_location const & =
                         felspar::source_location::current());
 

--- a/include/felspar/io/write.hpp
+++ b/include/felspar/io/write.hpp
@@ -26,6 +26,13 @@ namespace felspar::io {
     }
 
 
+    /// ## Try to write data
+    /**
+     * This performs a synchronous write of as much data as the socket can take at the moment. Write errors results in thrown exceptions.
+     */
+    std::size_t write_some(socket_descriptor, void *, std::size_t);
+
+
     /// ## Write all of the buffer to a file descriptor
     template<typename S>
     inline warden::task<std::size_t> write_all(

--- a/include/felspar/io/write.hpp
+++ b/include/felspar/io/write.hpp
@@ -28,9 +28,10 @@ namespace felspar::io {
 
     /// ## Try to write data
     /**
-     * This performs a synchronous write of as much data as the socket can take at the moment. Write errors results in thrown exceptions.
+     * This performs a synchronous write of as much data as the socket can take
+     * at the moment. Write errors results in thrown exceptions.
      */
-    std::size_t write_some(socket_descriptor, void *, std::size_t);
+    std::size_t write_some(socket_descriptor, void const *, std::size_t);
 
 
     /// ## Write all of the buffer to a file descriptor

--- a/src/convenience.cpp
+++ b/src/convenience.cpp
@@ -1,4 +1,5 @@
 #include <felspar/io/accept.hpp>
+#include <felspar/io/pipe.hpp>
 #include <felspar/io/read.hpp>
 #include <felspar/io/warden.hpp>
 #include <felspar/io/write.hpp>

--- a/src/convenience.cpp
+++ b/src/convenience.cpp
@@ -27,11 +27,13 @@ felspar::io::warden::stream<felspar::io::socket_descriptor> felspar::io::accept(
 }
 
 
-std::size_t felspar::io::write_some(socket_descriptor sock, void * const data, std::size_t const bytes) {
+std::size_t felspar::io::write_some(
+        socket_descriptor sock,
+        void const *const data,
+        std::size_t const bytes) {
 #ifdef FELSPAR_WINSOCK2
     if (auto const r =
-                ::send(sock, reinterpret_cast<char const *>(data),
-                        bytes, {});
+                ::send(sock, reinterpret_cast<char const *>(data), bytes, {});
         r != SOCKET_ERROR) {
 #else
     if (auto const r = ::write(sock, data, bytes); r >= 0) {
@@ -39,6 +41,7 @@ std::size_t felspar::io::write_some(socket_descriptor sock, void * const data, s
         return r;
     } else {
         throw felspar::stdexcept::system_error{
-                get_error(), std::system_category(), "Writing to socket\n" + std::to_string(bytes)};
+                get_error(), std::system_category(),
+                "Writing to socket\n" + std::to_string(bytes)};
     }
 }

--- a/src/convenience.cpp
+++ b/src/convenience.cpp
@@ -25,3 +25,20 @@ felspar::io::warden::stream<felspar::io::socket_descriptor> felspar::io::accept(
 #endif
     }
 }
+
+
+std::size_t felspar::io::write_some(socket_descriptor sock, void * const data, std::size_t const bytes) {
+#ifdef FELSPAR_WINSOCK2
+    if (auto const r =
+                ::send(sock, reinterpret_cast<char const *>(data),
+                        bytes, {});
+        r != SOCKET_ERROR) {
+#else
+    if (auto const r = ::write(sock, data, bytes); r >= 0) {
+#endif
+        return r;
+    } else {
+        throw felspar::stdexcept::system_error{
+                get_error(), std::system_category(), "Writing to socket\n" + std::to_string(bytes)};
+    }
+}

--- a/src/posix.cpp
+++ b/src/posix.cpp
@@ -8,15 +8,14 @@
 #endif
 
 
-auto felspar::posix::pipe::create() -> pipe {
+auto felspar::posix::pipe::create(felspar::source_location const &loc) -> pipe {
 #if defined(FELSPAR_POSIX_SOCKETS)
     int fds[2] = {};
     if (::pipe2(fds, O_NONBLOCK) == 0) {
         return {fd{fds[0]}, fd{fds[1]}};
     } else {
         throw felspar::stdexcept::system_error{
-                io::get_error(), std::system_category(),
-                "Creating pipe", loc};
+                io::get_error(), std::system_category(), "Creating pipe", loc};
     }
 #elif defined(FELSPAR_WINSOCK2)
     return {};

--- a/src/posix.cpp
+++ b/src/posix.cpp
@@ -88,14 +88,15 @@ void felspar::posix::set_reuse_port(
 }
 
 
-void felspar::posix::bind_to_any_address(
+void felspar::posix::bind(
         io::socket_descriptor const sock,
+        std::uint32_t const addr,
         std::uint16_t const port,
         felspar::source_location const &loc) {
     sockaddr_in in;
     in.sin_family = AF_INET;
     in.sin_port = htons(port);
-    in.sin_addr.s_addr = htonl(INADDR_ANY);
+    in.sin_addr.s_addr = htonl(addr);
     if (::bind(sock, reinterpret_cast<sockaddr const *>(&in), sizeof(in))
         != 0) {
         throw felspar::stdexcept::system_error{

--- a/src/posix.cpp
+++ b/src/posix.cpp
@@ -9,12 +9,20 @@
 
 
 auto felspar::posix::pipe::create() -> pipe {
+#if defined(FELSPAR_POSIX_SOCKETS)
     int fds[2] = {};
-    if (::pipe2(fds, O_NONBLOCK) != 0) {
+    if (::pipe2(fds, O_NONBLOCK) == 0) {
+        return {fd{fds[0]}, fd{fds[1]}};
+    } else {
         throw felspar::stdexcept::system_error{
-                errno, std::system_category(), "Calling pipe2"};
+                io::get_error(), std::system_category(),
+                "Creating pipe", loc};
     }
-    return {fd{fds[0]}, fd{fds[1]}};
+#elif defined(FELSPAR_WINSOCK2)
+    return {};
+#else
+#error "No implementation for this platform"
+#endif
 }
 
 

--- a/src/posix.cpp
+++ b/src/posix.cpp
@@ -8,23 +8,6 @@
 #endif
 
 
-auto felspar::posix::pipe::create(felspar::source_location const &loc) -> pipe {
-#if defined(FELSPAR_POSIX_SOCKETS)
-    int fds[2] = {};
-    if (::pipe2(fds, O_NONBLOCK) == 0) {
-        return {fd{fds[0]}, fd{fds[1]}};
-    } else {
-        throw felspar::stdexcept::system_error{
-                io::get_error(), std::system_category(), "Creating pipe", loc};
-    }
-#elif defined(FELSPAR_WINSOCK2)
-    return {};
-#else
-#error "No implementation for this platform"
-#endif
-}
-
-
 std::pair<std::size_t, std::size_t>
         felspar::posix::promise_to_never_use_select() {
 #ifdef FELSPAR_POSIX_SOCKETS

--- a/src/warden.cpp
+++ b/src/warden.cpp
@@ -29,8 +29,8 @@ auto felspar::io::warden::create_pipe(felspar::source_location const &loc)
     posix::fd server{::socket(AF_INET, SOCK_STREAM, 0)};
     if (not server) {
         throw felspar::stdexcept::system_error{
-                get_error(), std::system_category(), "Error creating pipe accept socket",
-                loc};
+                get_error(), std::system_category(),
+                "Error creating pipe accept socket", loc};
     }
     posix::bind(server, INADDR_LOOPBACK, 0);
     sockaddr name;

--- a/src/warden.cpp
+++ b/src/warden.cpp
@@ -26,8 +26,33 @@ felspar::posix::fd felspar::io::warden::create_socket(
 auto felspar::io::warden::create_pipe(felspar::source_location const &loc)
         -> pipe {
 #ifdef FELSPAR_WINSOCK2
-    throw felspar::stdexcept::runtime_error{
-            "Windows pipe creation is not implemented"};
+    auto server = create_socket(AF_INET, SOCK_STREAM, 0, loc);
+    posix::bind(server, INADDR_LOOPBACK, 0);
+    sockaddr name;
+    int namelen = sizeof(sockaddr);
+    if (getsockname(server.native_handle(), &name, &namelen) != 0) {
+        throw felspar::stdexcept::system_error{
+            io::get_error(), std::system_category(), "getsockname to determine port", loc};
+    }
+    posix::listen(server, 1, loc);
+
+    auto write = create_socket(AF_INET, SOCK_STREAM, 0, loc);
+    if (::connect(write.native_handle(), &name, namelen) != 0) {
+        auto const error = io::get_error();
+        if (error != WSAEWOULDBLOCK) {
+            throw felspar::stdexcept::system_error{
+                error, std::system_category(), "connecting write end part 1", loc};
+        }
+    } else {
+        throw felspar::stdexcept::runtime_error{"Expected WSAEWOULDBLOCK when connecting write end", loc};
+    }
+
+    auto read = posix::fd{::accept(server.native_handle(), &name, &namelen)};
+    if (not read) {
+        throw felspar::stdexcept::runtime_error{"Didn't get a valid read socket from accept"};
+    }
+
+    return {std::move(read), std::move(write)};
 #else
     int fds[2] = {};
     if (::pipe2(fds, O_NONBLOCK) == 0) {

--- a/src/warden.cpp
+++ b/src/warden.cpp
@@ -32,7 +32,8 @@ auto felspar::io::warden::create_pipe(felspar::source_location const &loc)
     int namelen = sizeof(sockaddr);
     if (getsockname(server.native_handle(), &name, &namelen) != 0) {
         throw felspar::stdexcept::system_error{
-            io::get_error(), std::system_category(), "getsockname to determine port", loc};
+                io::get_error(), std::system_category(),
+                "getsockname to determine port", loc};
     }
     posix::listen(server, 1, loc);
 
@@ -41,15 +42,18 @@ auto felspar::io::warden::create_pipe(felspar::source_location const &loc)
         auto const error = io::get_error();
         if (error != WSAEWOULDBLOCK) {
             throw felspar::stdexcept::system_error{
-                error, std::system_category(), "connecting write end part 1", loc};
+                    error, std::system_category(),
+                    "connecting write end part 1", loc};
         }
     } else {
-        throw felspar::stdexcept::runtime_error{"Expected WSAEWOULDBLOCK when connecting write end", loc};
+        throw felspar::stdexcept::runtime_error{
+                "Expected WSAEWOULDBLOCK when connecting write end", loc};
     }
 
     auto read = posix::fd{::accept(server.native_handle(), &name, &namelen)};
     if (not read) {
-        throw felspar::stdexcept::runtime_error{"Didn't get a valid read socket from accept"};
+        throw felspar::stdexcept::runtime_error{
+                "Didn't get a valid read socket from accept"};
     }
 
     return {std::move(read), std::move(write)};

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -1,21 +1,27 @@
-add_library(felspar-io-headers-tests STATIC EXCLUDE_FROM_ALL
-        accept.cpp
-        completion.cpp
-        connect.cpp
-        error.cpp
-        exceptions.cpp
-        io.cpp
-        posix.cpp
-        read.cpp
-        tls.cpp
-        warden.cpp
-        warden.poll.cpp
-        write.cpp
-    )
-if(${FELSPAR_ENABLE_IO_URING})
-    target_sources(felspar-io-headers-tests PRIVATE
-            warden.uring.cpp
+if(TARGET felspar-check)
+
+
+    add_library(felspar-io-headers-tests STATIC EXCLUDE_FROM_ALL
+            accept.cpp
+            completion.cpp
+            connect.cpp
+            error.cpp
+            exceptions.cpp
+            io.cpp
+            posix.cpp
+            read.cpp
+            tls.cpp
+            warden.cpp
+            warden.poll.cpp
+            write.cpp
         )
+    if(${FELSPAR_ENABLE_IO_URING})
+        target_sources(felspar-io-headers-tests PRIVATE
+                warden.uring.cpp
+            )
+    endif()
+    target_link_libraries(felspar-io-headers-tests felspar-io)
+    add_dependencies(felspar-check felspar-io-headers-tests)
+
+
 endif()
-target_link_libraries(felspar-io-headers-tests felspar-io)
-add_dependencies(felspar-check felspar-io-headers-tests)

--- a/test/run/pipe.cpp
+++ b/test/run/pipe.cpp
@@ -1,6 +1,13 @@
 #include <felspar/io/posix.hpp>
 #include <felspar/test.hpp>
 
+#include <felspar/io/read.hpp>
+#include <felspar/io/warden.poll.hpp>
+#include <felspar/io/write.hpp>
+
+
+using namespace std::literals;
+
 
 namespace {
 
@@ -12,6 +19,32 @@ namespace {
         auto p = felspar::posix::pipe::create();
         check(p.read).is_truthy();
         check(p.write).is_truthy();
+    });
+
+
+    auto const tp = suite.test("transmission", []() {
+        felspar::io::poll_warden ward;
+        auto pipe = felspar::posix::pipe::create();
+        ward.run(
+                +[](felspar::io::warden &ward, felspar::posix::pipe &pipe)
+                        -> felspar::io::warden::task<void> {
+                    felspar::test::injected check;
+
+                    std::array<std::uint8_t, 6> out{1, 2, 3, 4, 5, 6}, buffer{};
+                    co_await felspar::io::write_all(
+                            ward, pipe.write, out, 20ms);
+
+                    auto bytes = co_await felspar::io::read_exactly(
+                            ward, pipe.read, buffer, 20ms);
+                    check(bytes) == 6u;
+                    check(buffer[0]) == out[0];
+                    check(buffer[1]) == out[1];
+                    check(buffer[2]) == out[2];
+                    check(buffer[3]) == out[3];
+                    check(buffer[4]) == out[4];
+                    check(buffer[5]) == out[5];
+                },
+                std::ref(pipe));
     });
 
 

--- a/test/run/pipe.cpp
+++ b/test/run/pipe.cpp
@@ -23,52 +23,60 @@ namespace {
     });
 
 
-    auto const tp = suite.test("transmission", []() {
-        felspar::io::poll_warden ward;
-        ward.run(
-                +[](felspar::io::warden &ward)
-                        -> felspar::io::warden::task<void> {
-                    felspar::test::injected check;
+    auto const tp = suite.test(
+            "transmission",
+            []() {
+                felspar::io::poll_warden ward;
+                ward.run(
+                        +[](felspar::io::warden &ward)
+                                -> felspar::io::warden::task<void> {
+                            felspar::test::injected check;
 
-                    auto pipe = ward.create_pipe();
+                            auto pipe = ward.create_pipe();
 
-                    std::array<std::uint8_t, 6> out{1, 2, 3, 4, 5, 6}, buffer{};
-                    co_await felspar::io::write_all(
-                            ward, pipe.write, out, 20ms);
+                            std::array<std::uint8_t, 6> out{1, 2, 3, 4, 5, 6},
+                                    buffer{};
+                            co_await felspar::io::write_all(
+                                    ward, pipe.write, out, 20ms);
 
-                    auto bytes = co_await felspar::io::read_exactly(
-                            ward, pipe.read, buffer, 20ms);
-                    check(bytes) == 6u;
-                    check(buffer[0]) == out[0];
-                    check(buffer[1]) == out[1];
-                    check(buffer[2]) == out[2];
-                    check(buffer[3]) == out[3];
-                    check(buffer[4]) == out[4];
-                    check(buffer[5]) == out[5];
-                });
-    }, []() {
-        felspar::io::poll_warden ward;
-        ward.run(
-                +[](felspar::io::warden &ward)
-                        -> felspar::io::warden::task<void> {
-                    felspar::test::injected check;
+                            auto bytes = co_await felspar::io::read_exactly(
+                                    ward, pipe.read, buffer, 20ms);
+                            check(bytes) == 6u;
+                            check(buffer[0]) == out[0];
+                            check(buffer[1]) == out[1];
+                            check(buffer[2]) == out[2];
+                            check(buffer[3]) == out[3];
+                            check(buffer[4]) == out[4];
+                            check(buffer[5]) == out[5];
+                        });
+            },
+            []() {
+                felspar::io::poll_warden ward;
+                ward.run(
+                        +[](felspar::io::warden &ward)
+                                -> felspar::io::warden::task<void> {
+                            felspar::test::injected check;
 
-                    auto pipe = ward.create_pipe();
+                            auto pipe = ward.create_pipe();
 
-                    std::array<std::uint8_t, 6> out{1, 2, 3, 4, 5, 6}, buffer{};
-                    check(felspar::io::write_some(pipe.write.native_handle(), out.data(), out.size())) == out.size();
+                            std::array<std::uint8_t, 6> out{1, 2, 3, 4, 5, 6},
+                                    buffer{};
+                            check(felspar::io::write_some(
+                                    pipe.write.native_handle(), out.data(),
+                                    out.size()))
+                                    == out.size();
 
-                    auto bytes = co_await felspar::io::read_exactly(
-                            ward, pipe.read, buffer, 20ms);
-                    check(bytes) == 6u;
-                    check(buffer[0]) == out[0];
-                    check(buffer[1]) == out[1];
-                    check(buffer[2]) == out[2];
-                    check(buffer[3]) == out[3];
-                    check(buffer[4]) == out[4];
-                    check(buffer[5]) == out[5];
-                });
-    });
+                            auto bytes = co_await felspar::io::read_exactly(
+                                    ward, pipe.read, buffer, 20ms);
+                            check(bytes) == 6u;
+                            check(buffer[0]) == out[0];
+                            check(buffer[1]) == out[1];
+                            check(buffer[2]) == out[2];
+                            check(buffer[3]) == out[3];
+                            check(buffer[4]) == out[4];
+                            check(buffer[5]) == out[5];
+                        });
+            });
 
 
 }

--- a/test/run/pipe.cpp
+++ b/test/run/pipe.cpp
@@ -46,6 +46,28 @@ namespace {
                     check(buffer[4]) == out[4];
                     check(buffer[5]) == out[5];
                 });
+    }, []() {
+        felspar::io::poll_warden ward;
+        ward.run(
+                +[](felspar::io::warden &ward)
+                        -> felspar::io::warden::task<void> {
+                    felspar::test::injected check;
+
+                    auto pipe = ward.create_pipe();
+
+                    std::array<std::uint8_t, 6> out{1, 2, 3, 4, 5, 6}, buffer{};
+                    check(felspar::io::write_some(pipe.write.native_handle(), out.data(), out.size())) == out.size();
+
+                    auto bytes = co_await felspar::io::read_exactly(
+                            ward, pipe.read, buffer, 20ms);
+                    check(bytes) == 6u;
+                    check(buffer[0]) == out[0];
+                    check(buffer[1]) == out[1];
+                    check(buffer[2]) == out[2];
+                    check(buffer[3]) == out[3];
+                    check(buffer[4]) == out[4];
+                    check(buffer[5]) == out[5];
+                });
     });
 
 


### PR DESCRIPTION
Windows doesn't have a good way to deal with pipes that plays well with `SOCKET`. So, we simulate a pipe by opening a socket pair through `localhost`