### PR TITLE
Add tests for exception handling

### DIFF
--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -3,6 +3,7 @@ if(TARGET felspar-check)
             allocators.cpp
             basics.cpp
             cancel.cpp
+            exceptions.cpp
             pipe.cpp
             run_batch.cpp
             timers.cpp

--- a/test/run/exceptions.cpp
+++ b/test/run/exceptions.cpp
@@ -17,8 +17,8 @@ namespace {
 
 
     auto const wrep = suite.test("early poll", [](auto check) {
-        felspar::io::poll_warden ward;
         check([&]() {
+            felspar::io::poll_warden ward;
             ward.run(
                     +[](felspar::io::warden &)
                             -> felspar::io::warden::task<void> {
@@ -30,8 +30,8 @@ namespace {
 
 
     auto const wrlp = suite.test("late poll", [](auto check) {
-        felspar::io::poll_warden ward;
         check([&]() {
+            felspar::io::poll_warden ward;
             ward.run(
                     +[](felspar::io::warden &ward)
                             -> felspar::io::warden::task<void> {
@@ -44,8 +44,8 @@ namespace {
 
 #ifdef FELSPAR_ENABLE_IO_URING
     auto const wreu = suite.test("early io_uring", [](auto check) {
-        felspar::io::uring_warden ward;
         check([&]() {
+            felspar::io::uring_warden ward;
             ward.run(
                     +[](felspar::io::warden &)
                             -> felspar::io::warden::task<void> {
@@ -57,8 +57,8 @@ namespace {
 
 
     auto const wrlu = suite.test("late io_uring", [](auto check) {
-        felspar::io::uring_warden ward;
         check([&]() {
+            felspar::io::uring_warden ward;
             ward.run(
                     +[](felspar::io::warden &ward)
                             -> felspar::io::warden::task<void> {

--- a/test/run/exceptions.cpp
+++ b/test/run/exceptions.cpp
@@ -1,0 +1,73 @@
+#include <felspar/io.hpp>
+#include <felspar/test.hpp>
+
+
+using namespace std::literals;
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("warden::run exceptions");
+
+
+    void always_throw() {
+        throw felspar::stdexcept::runtime_error{"Forced exception"};
+    }
+
+
+    auto const wrep = suite.test("early poll", [](auto check) {
+        felspar::io::poll_warden ward;
+        check([&]() {
+            ward.run(
+                    +[](felspar::io::warden &)
+                            -> felspar::io::warden::task<void> {
+                        always_throw();
+                        co_return;
+                    });
+        }).template throws_type<felspar::stdexcept::runtime_error>();
+    });
+
+
+    auto const wrlp = suite.test("late poll", [](auto check) {
+        felspar::io::poll_warden ward;
+        check([&]() {
+            ward.run(
+                    +[](felspar::io::warden &ward)
+                            -> felspar::io::warden::task<void> {
+                        co_await ward.sleep(10ms);
+                        always_throw();
+                    });
+        }).template throws_type<felspar::stdexcept::runtime_error>();
+    });
+
+
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const wreu = suite.test("early io_uring", [](auto check) {
+        felspar::io::uring_warden ward;
+        check([&]() {
+            ward.run(
+                    +[](felspar::io::warden &)
+                            -> felspar::io::warden::task<void> {
+                        always_throw();
+                        co_return;
+                    });
+        }).template throws_type<felspar::stdexcept::runtime_error>();
+    });
+
+
+    auto const wrlu = suite.test("late io_uring", [](auto check) {
+        felspar::io::uring_warden ward;
+        check([&]() {
+            ward.run(
+                    +[](felspar::io::warden &ward)
+                            -> felspar::io::warden::task<void> {
+                        co_await ward.sleep(10ms);
+                        always_throw();
+                    });
+        }).template throws_type<felspar::stdexcept::runtime_error>();
+    });
+#endif
+
+
+}


### PR DESCRIPTION
Sometimes there seems to be some problem with exceptions. There appears to be a double free of the coroutine handle that is given to the `run` method on the warden.

I can't tell if it's a compiler getting confused or a real bug, so adding some tests to try to reproduce as best as possible.