### PR TITLE
Zero read

### DIFF
--- a/include/felspar/io/read.hpp
+++ b/include/felspar/io/read.hpp
@@ -93,8 +93,7 @@ namespace felspar::io {
             std::size_t const bytes_read =
                     co_await read_some(ward, sock, remaining(), timeout, loc);
             if (bytes_read == 0) {
-                throw stdexcept::runtime_error{
-                        "Got a zero read, we're done", loc};
+                co_return 0;
             } else {
                 data_read = {data_read.data(), data_read.size() + bytes_read};
                 empty_buffer = empty_buffer.subspan(bytes_read);

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -68,7 +68,7 @@ struct felspar::io::tls::impl {
 
             default:
                 throw felspar::stdexcept::runtime_error{
-                        "Unknown openssl error " + std::to_string(error), loc};
+                        "Unknown openssl error " + std::to_string(error)};
             }
         }
     }


### PR DESCRIPTION
Properly handle zero byte reads. These happen when the remote end closes the socket and all of the remaining data that was written has now been read.