### PR TITLE
Deadlines

### DIFF
--- a/config-builds
+++ b/config-builds
@@ -24,7 +24,6 @@ linux && CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-release \
 
 
 export CXXFLAGS=-stdlib=libc++
-export LD_FLAGS=-stdlib=libc++
 
 CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-debug-libc++ \
     -DCMAKE_INSTALL_PREFIX=dist/clang-debug-libc++
@@ -35,7 +34,7 @@ CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-release-libc++ \
 
 
 # We can't use `undefined` sanitizer with coroutines due to clang bug :-(
-export CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+export CXXFLAGS="-stdlib=libc++ -fsanitize=address"
 
 CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-debug-asan \
     -DCMAKE_INSTALL_PREFIX=dist/clang-debug-asan
@@ -46,10 +45,10 @@ CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-release-asan \
 
 
 linux && CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-debug--io_uring-asan \
-    -DFELSPAR_ENABLE_IO_URING=NO \
+    -DFELSPAR_ENABLE_IO_URING=ON \
     -DCMAKE_INSTALL_PREFIX=dist/clang-debug--io_uring-asan
 
 linux && CC=clang CXX=clang++ $CMAKE -B build.tmp/clang-release--io_uring-asan \
-    -DFELSPAR_ENABLE_IO_URING=NO \
+    -DFELSPAR_ENABLE_IO_URING=ON \
     -DCMAKE_INSTALL_PREFIX=dist/clang-release--io_uring-asan \
     -DCMAKE_BUILD_TYPE=Release

--- a/include/felspar/io.hpp
+++ b/include/felspar/io.hpp
@@ -5,6 +5,7 @@
 #include <felspar/io/addrinfo.hpp>
 #include <felspar/io/allocator.hpp>
 #include <felspar/io/connect.hpp>
+#include <felspar/io/deadline.hpp>
 #include <felspar/io/error.hpp>
 #include <felspar/io/exceptions.hpp>
 #include <felspar/io/pipe.hpp>

--- a/include/felspar/io/allocator.hpp
+++ b/include/felspar/io/allocator.hpp
@@ -56,14 +56,14 @@ namespace felspar::io {
         iop<std::size_t> do_read_some(
                 socket_descriptor const fd,
                 std::span<std::byte> const buffer,
-                std::optional<std::chrono::nanoseconds> const timeout,
+                std::optional<deadline> const timeout,
                 std::source_location const loc) override {
             return backing_warden.do_read_some(fd, buffer, timeout, loc);
         }
         iop<std::size_t> do_write_some(
                 socket_descriptor const fd,
                 std::span<std::byte const> const buffer,
-                std::optional<std::chrono::nanoseconds> const timeout,
+                std::optional<deadline> const timeout,
                 std::source_location const loc) override {
             return backing_warden.do_write_some(fd, buffer, timeout, loc);
         }
@@ -74,7 +74,7 @@ namespace felspar::io {
         }
         iop<socket_descriptor> do_accept(
                 socket_descriptor const fd,
-                std::optional<std::chrono::nanoseconds> const timeout,
+                std::optional<deadline> const timeout,
                 std::source_location const loc) override {
             return backing_warden.do_accept(fd, timeout, loc);
         }
@@ -82,19 +82,19 @@ namespace felspar::io {
                 socket_descriptor const fd,
                 sockaddr const *const addr,
                 socklen_t const len,
-                std::optional<std::chrono::nanoseconds> const timeout,
+                std::optional<deadline> const timeout,
                 std::source_location const loc) override {
             return backing_warden.do_connect(fd, addr, len, timeout, loc);
         }
         iop<void> do_read_ready(
                 socket_descriptor const fd,
-                std::optional<std::chrono::nanoseconds> const timeout,
+                std::optional<deadline> const timeout,
                 std::source_location const loc) override {
             return backing_warden.do_read_ready(fd, timeout, loc);
         }
         iop<void> do_write_ready(
                 socket_descriptor const fd,
-                std::optional<std::chrono::nanoseconds> const timeout,
+                std::optional<deadline> const timeout,
                 std::source_location const loc) override {
             return backing_warden.do_write_ready(fd, timeout, loc);
         }

--- a/include/felspar/io/connect.hpp
+++ b/include/felspar/io/connect.hpp
@@ -36,13 +36,13 @@ namespace felspar::io {
 
     /// ## Return a new socket connected to an address
     warden::task<posix::fd> connect(
-            warden &ward,
+            warden &,
             char const *hostname,
             std::uint16_t port,
             std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current());
     FELSPAR_CORO_WRAPPER warden::task<posix::fd> connect(
-            warden &ward,
+            warden &,
             char const *hostname,
             std::uint16_t port,
             std::chrono::nanoseconds timeout,
@@ -52,6 +52,12 @@ namespace felspar::io {
      * to connect to them in turn. Returns the first one that works. If all of
      * them fail it throws the exception associated with the last one tried.
      * Also throws if no hosts are returned.
+     *
+     * TODO Going through them one by one interacts badly with deadlines when a
+     * host connect times out because none of the following hosts are going to
+     * be given a chance to connect. This needs to implement something like
+     * ["Happy eyeballs"](https://en.wikipedia.org/wiki/Happy_Eyeballs) instead
+     * so that it can try multiple addresses together.
      */
 
 

--- a/include/felspar/io/connect.hpp
+++ b/include/felspar/io/connect.hpp
@@ -15,13 +15,22 @@ namespace felspar::io {
             Socket &&sock,
             sockaddr const *const addr,
             socklen_t const addrlen,
-            std::optional<std::chrono::nanoseconds> const timeout = {},
+            std::optional<deadline> deadline = {},
+            std::source_location const loc = std::source_location::current()) {
+        return ward.connect(
+                std::forward<Socket>(sock), addr, addrlen, deadline, loc);
+    }
+    template<typename Socket>
+    inline auto connect(
+            warden &ward,
+            Socket &&sock,
+            sockaddr const *const addr,
+            socklen_t const addrlen,
+            std::chrono::nanoseconds const timeout,
             std::source_location const loc = std::source_location::current()) {
         return ward.connect(
                 std::forward<Socket>(sock), addr, addrlen,
-                timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                        : std::nullopt,
-                loc);
+                deadline_from(timeout), loc);
     }
 
 
@@ -30,7 +39,13 @@ namespace felspar::io {
             warden &ward,
             char const *hostname,
             std::uint16_t port,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
+            std::source_location const loc = std::source_location::current());
+    FELSPAR_CORO_WRAPPER warden::task<posix::fd> connect(
+            warden &ward,
+            char const *hostname,
+            std::uint16_t port,
+            std::chrono::nanoseconds timeout,
             std::source_location const loc = std::source_location::current());
     /**
      * Goes through each host address associated with the `hostname` and tries

--- a/include/felspar/io/connect.hpp
+++ b/include/felspar/io/connect.hpp
@@ -18,7 +18,10 @@ namespace felspar::io {
             std::optional<std::chrono::nanoseconds> const timeout = {},
             std::source_location const loc = std::source_location::current()) {
         return ward.connect(
-                std::forward<Socket>(sock), addr, addrlen, timeout, loc);
+                std::forward<Socket>(sock), addr, addrlen,
+                timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                        : std::nullopt,
+                loc);
     }
 
 

--- a/include/felspar/io/deadline.hpp
+++ b/include/felspar/io/deadline.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+
+#include <chrono>
+
+
+namespace felspar::io {
+
+
+    /// ## Deadlines
+    using deadline = std::chrono::steady_clock::time_point;
+    /**
+     * A `deadline` is the absolute point in time by which an operation must
+     * complete. A missing deadline (`std::nullopt`) means the operation has no
+     * deadline and may run forever.
+     */
+
+
+    /// ### Conversion
+    inline deadline deadline_from(std::chrono::nanoseconds timeout) {
+        return std::chrono::steady_clock::now() + timeout;
+    }
+
+
+}

--- a/include/felspar/io/read.hpp
+++ b/include/felspar/io/read.hpp
@@ -19,13 +19,18 @@ namespace felspar::io {
             io::warden &warden,
             S &&sock,
             B &&buffer,
-            std::optional<std::chrono::nanoseconds> const timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
-        return warden.read_some(
-                sock, buffer,
-                timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                        : std::nullopt,
-                loc);
+        return warden.read_some(sock, buffer, deadline, loc);
+    }
+    template<typename S, typename B>
+    inline auto read_some(
+            io::warden &warden,
+            S &&sock,
+            B &&buffer,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return warden.read_some(sock, buffer, deadline_from(timeout), loc);
     }
 
 
@@ -90,11 +95,11 @@ namespace felspar::io {
         warden::task<std::size_t> do_read_some(
                 warden &ward,
                 S &&sock,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
             std::size_t const bytes_read =
-                    co_await read_some(ward, sock, remaining(), timeout, loc);
+                    co_await read_some(ward, sock, remaining(), deadline, loc);
             if (bytes_read == 0) {
                 co_return 0;
             } else {
@@ -102,6 +107,16 @@ namespace felspar::io {
                 empty_buffer = empty_buffer.subspan(bytes_read);
                 co_return bytes_read;
             }
+        }
+        template<typename S>
+        FELSPAR_CORO_WRAPPER warden::task<std::size_t> do_read_some(
+                warden &ward,
+                S &&sock,
+                std::chrono::nanoseconds const timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return do_read_some(
+                    ward, std::forward<S>(sock), deadline_from(timeout), loc);
         }
 
 
@@ -144,11 +159,12 @@ namespace felspar::io {
             warden &ward,
             S &&sock,
             std::span<std::byte> b,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         std::span<std::byte> in{b};
         while (in.size()) {
-            auto const bytes = co_await read_some(ward, sock, in, timeout, loc);
+            auto const bytes =
+                    co_await read_some(ward, sock, in, deadline, loc);
             if (not bytes) { co_return b.size() - in.size(); }
             in = in.subspan(bytes);
         }
@@ -156,29 +172,65 @@ namespace felspar::io {
     }
     template<typename S>
     FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> read_exactly(
+            warden &ward,
+            S &&sock,
+            std::span<std::byte> b,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return read_exactly(
+                ward, std::forward<S>(sock), b, deadline_from(timeout), loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> read_exactly(
             warden &w,
             S &&s,
             void *buf,
             std::size_t count,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         return read_exactly(
                 w, std::forward<S>(s),
                 std::span<std::byte>{reinterpret_cast<std::byte *>(buf), count},
-                std::move(timeout), loc);
+                deadline, loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> read_exactly(
+            warden &w,
+            S &&s,
+            void *buf,
+            std::size_t count,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return read_exactly(
+                w, std::forward<S>(s),
+                std::span<std::byte>{reinterpret_cast<std::byte *>(buf), count},
+                deadline_from(timeout), loc);
     }
     template<typename S>
     FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> read_exactly(
             warden &w,
             S &&s,
             std::span<std::uint8_t> b,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         return read_exactly(
                 w, std::forward<S>(s),
                 std::span<std::byte>{
                         reinterpret_cast<std::byte *>(b.data()), b.size()},
-                std::move(timeout), loc);
+                deadline, loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> read_exactly(
+            warden &w,
+            S &&s,
+            std::span<std::uint8_t> b,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return read_exactly(
+                w, std::forward<S>(s),
+                std::span<std::byte>{
+                        reinterpret_cast<std::byte *>(b.data()), b.size()},
+                deadline_from(timeout), loc);
     }
 
 
@@ -192,12 +244,12 @@ namespace felspar::io {
             warden &ward,
             S &&sock,
             R &read_buffer,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         auto cr = read_buffer.find('\n');
         while (cr == read_buffer.end()) {
-            auto const bytes =
-                    co_await read_buffer.do_read_some(ward, sock, timeout, loc);
+            auto const bytes = co_await read_buffer.do_read_some(
+                    ward, sock, deadline, loc);
             if (bytes == 0) { co_return {}; }
             cr = read_buffer.find('\n');
         }
@@ -208,6 +260,19 @@ namespace felspar::io {
         } else {
             co_return read;
         }
+    }
+    template<typename S, typename R>
+    FELSPAR_CORO_WRAPPER inline warden::task<typename R::span_type>
+            read_until_lf_strip_cr(
+                    warden &ward,
+                    S &&sock,
+                    R &read_buffer,
+                    std::chrono::nanoseconds const timeout,
+                    std::source_location const loc =
+                            std::source_location::current()) {
+        return read_until_lf_strip_cr(
+                ward, std::forward<S>(sock), read_buffer,
+                deadline_from(timeout), loc);
     }
 
 

--- a/include/felspar/io/read.hpp
+++ b/include/felspar/io/read.hpp
@@ -21,7 +21,11 @@ namespace felspar::io {
             B &&buffer,
             std::optional<std::chrono::nanoseconds> const timeout = {},
             std::source_location const loc = std::source_location::current()) {
-        return warden.read_some(sock, buffer, timeout, loc);
+        return warden.read_some(
+                sock, buffer,
+                timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                        : std::nullopt,
+                loc);
     }
 
 

--- a/include/felspar/io/tls.hpp
+++ b/include/felspar/io/tls.hpp
@@ -31,35 +31,72 @@ namespace felspar::io {
                         char const *snI_hostname,
                         sockaddr const *addr,
                         socklen_t addrlen,
-                        std::optional<std::chrono::nanoseconds> timeout = {},
+                        std::optional<deadline> = {},
                         std::source_location = std::source_location::current());
-        static warden::task<tls> connect(
-                warden &ward,
-                char const *const hostname,
-                std::uint16_t const port = 443,
-                std::optional<std::chrono::nanoseconds> const timeout = {},
-                std::source_location const loc =
-                        std::source_location::current());
+        static warden::task<tls>
+                connect(warden &ward,
+                        char const *const hostname,
+                        std::uint16_t const port = 443,
+                        std::optional<deadline> = {},
+                        std::source_location const loc =
+                                std::source_location::current());
         /**
          * Goes through each host address associated with the `hostname` and
          * tries to connect to them in turn. Returns the first one that works.
          * If all of them fail it throws the exception associated with the last
          * one tried. Also throws if no hosts are returned.
          */
+        FELSPAR_CORO_WRAPPER static warden::task<tls>
+                connect(warden &warden,
+                        char const *const sni_hostname,
+                        sockaddr const *const addr,
+                        socklen_t const addrlen,
+                        std::chrono::nanoseconds const timeout,
+                        std::source_location const loc =
+                                std::source_location::current()) {
+            return connect(
+                    warden, sni_hostname, addr, addrlen, deadline_from(timeout),
+                    loc);
+        }
+        FELSPAR_CORO_WRAPPER static warden::task<tls>
+                connect(warden &ward,
+                        char const *const hostname,
+                        std::uint16_t const port,
+                        std::chrono::nanoseconds const timeout,
+                        std::source_location const loc =
+                                std::source_location::current()) {
+            return connect(ward, hostname, port, deadline_from(timeout), loc);
+        }
 
 
         /// Read from the connection
         warden::task<std::size_t> read_some(
                 warden &w,
                 std::span<std::byte>,
-                std::optional<std::chrono::nanoseconds> const timeout = {},
+                std::optional<deadline> = {},
                 std::source_location = std::source_location::current());
+        FELSPAR_CORO_WRAPPER warden::task<std::size_t> read_some(
+                warden &w,
+                std::span<std::byte> const s,
+                std::chrono::nanoseconds const timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return read_some(w, s, deadline_from(timeout), loc);
+        }
         /// Write to the connection
         warden::task<std::size_t> write_some(
                 warden &w,
                 std::span<std::byte const>,
-                std::optional<std::chrono::nanoseconds> const timeout = {},
+                std::optional<deadline> = {},
                 std::source_location = std::source_location::current());
+        FELSPAR_CORO_WRAPPER warden::task<std::size_t> write_some(
+                warden &w,
+                std::span<std::byte const> const s,
+                std::chrono::nanoseconds const timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return write_some(w, s, deadline_from(timeout), loc);
+        }
     };
 
 
@@ -69,17 +106,33 @@ namespace felspar::io {
             warden &w,
             tls &cnx,
             std::span<std::byte> const s,
-            std::optional<std::chrono::nanoseconds> const timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
-        return cnx.read_some(w, s, timeout, loc);
+        return cnx.read_some(w, s, deadline, loc);
+    }
+    FELSPAR_CORO_WRAPPER inline auto read_some(
+            warden &w,
+            tls &cnx,
+            std::span<std::byte> const s,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return cnx.read_some(w, s, deadline_from(timeout), loc);
     }
     FELSPAR_CORO_WRAPPER inline auto write_some(
             warden &w,
             tls &cnx,
             std::span<std::byte const> const s,
-            std::optional<std::chrono::nanoseconds> const timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
-        return cnx.write_some(w, s, timeout, loc);
+        return cnx.write_some(w, s, deadline, loc);
+    }
+    FELSPAR_CORO_WRAPPER inline auto write_some(
+            warden &w,
+            tls &cnx,
+            std::span<std::byte const> const s,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return cnx.write_some(w, s, deadline_from(timeout), loc);
     }
 
 

--- a/include/felspar/io/warden.hpp
+++ b/include/felspar/io/warden.hpp
@@ -96,7 +96,11 @@ namespace felspar::io {
                 std::optional<std::chrono::nanoseconds> timeout,
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_read_some(fd, s, timeout, loc);
+            return do_read_some(
+                    fd, s,
+                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                            : std::nullopt,
+                    loc);
         }
         iop<std::size_t> read_some(
                 posix::fd const &s,
@@ -111,7 +115,11 @@ namespace felspar::io {
                 std::optional<std::chrono::nanoseconds> timeout = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_write_some(fd, s, timeout, loc);
+            return do_write_some(
+                    fd, s,
+                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                            : std::nullopt,
+                    loc);
         }
         iop<std::size_t> write_some(
                 posix::fd const &s,
@@ -155,7 +163,11 @@ namespace felspar::io {
                        std::optional<std::chrono::nanoseconds> timeout = {},
                        std::source_location const loc =
                                std::source_location::current()) {
-            return do_accept(fd, timeout, loc);
+            return do_accept(
+                    fd,
+                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                            : std::nullopt,
+                    loc);
         }
         iop<socket_descriptor>
                 accept(posix::fd const &sock,
@@ -171,7 +183,11 @@ namespace felspar::io {
                         std::optional<std::chrono::nanoseconds> timeout = {},
                         std::source_location const loc =
                                 std::source_location::current()) {
-            return do_connect(fd, addr, addrlen, timeout, loc);
+            return do_connect(
+                    fd, addr, addrlen,
+                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                            : std::nullopt,
+                    loc);
         }
         iop<void>
                 connect(posix::fd const &sock,
@@ -190,7 +206,11 @@ namespace felspar::io {
                 std::optional<std::chrono::nanoseconds> timeout = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_read_ready(fd, timeout, loc);
+            return do_read_ready(
+                    fd,
+                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                            : std::nullopt,
+                    loc);
         }
         iop<void> read_ready(
                 posix::fd const &sock,
@@ -204,7 +224,11 @@ namespace felspar::io {
                 std::optional<std::chrono::nanoseconds> timeout = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_write_ready(fd, timeout, loc);
+            return do_write_ready(
+                    fd,
+                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                            : std::nullopt,
+                    loc);
         }
         iop<void> write_ready(
                 posix::fd const &sock,
@@ -242,32 +266,32 @@ namespace felspar::io {
         virtual iop<std::size_t> do_read_some(
                 socket_descriptor fd,
                 std::span<std::byte>,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) = 0;
         virtual iop<std::size_t> do_write_some(
                 socket_descriptor fd,
                 std::span<std::byte const>,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) = 0;
         virtual void do_prepare_socket(socket_descriptor, std::source_location) {
         }
         virtual iop<socket_descriptor> do_accept(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) = 0;
         virtual iop<void> do_connect(
                 socket_descriptor fd,
                 sockaddr const *,
                 socklen_t,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) = 0;
         virtual iop<void> do_read_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) = 0;
         virtual iop<void> do_write_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) = 0;
     };
 

--- a/include/felspar/io/warden.hpp
+++ b/include/felspar/io/warden.hpp
@@ -3,6 +3,7 @@
 #include <felspar/coro/starter.hpp>
 #include <felspar/coro/stream.hpp>
 #include <felspar/io/completion.hpp>
+#include <felspar/io/deadline.hpp>
 #include <felspar/io/pipe.hpp>
 #include <felspar/io/posix.hpp>
 #include <felspar/memory/pmr.hpp>

--- a/include/felspar/io/warden.hpp
+++ b/include/felspar/io/warden.hpp
@@ -93,40 +93,62 @@ namespace felspar::io {
         iop<std::size_t> read_some(
                 socket_descriptor fd,
                 std::span<std::byte> s,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_read_some(
-                    fd, s,
-                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                            : std::nullopt,
-                    loc);
+            return do_read_some(fd, s, deadline, loc);
+        }
+        iop<std::size_t> read_some(
+                socket_descriptor fd,
+                std::span<std::byte> s,
+                std::chrono::nanoseconds timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return read_some(fd, s, deadline_from(timeout), loc);
         }
         iop<std::size_t> read_some(
                 posix::fd const &s,
                 std::span<std::byte> b,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const l = std::source_location::current()) {
-            return read_some(s.native_handle(), b, timeout, l);
+            return read_some(s.native_handle(), b, deadline, l);
+        }
+        iop<std::size_t> read_some(
+                posix::fd const &s,
+                std::span<std::byte> b,
+                std::chrono::nanoseconds timeout,
+                std::source_location const l = std::source_location::current()) {
+            return read_some(s.native_handle(), b, deadline_from(timeout), l);
         }
         iop<std::size_t> write_some(
                 socket_descriptor fd,
                 std::span<std::byte const> s,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_write_some(
-                    fd, s,
-                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                            : std::nullopt,
-                    loc);
+            return do_write_some(fd, s, deadline, loc);
+        }
+        iop<std::size_t> write_some(
+                socket_descriptor fd,
+                std::span<std::byte const> s,
+                std::chrono::nanoseconds timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return write_some(fd, s, deadline_from(timeout), loc);
         }
         iop<std::size_t> write_some(
                 posix::fd const &s,
                 std::span<std::byte const> b,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const l = std::source_location::current()) {
-            return write_some(s.native_handle(), b, timeout, l);
+            return write_some(s.native_handle(), b, deadline, l);
+        }
+        iop<std::size_t> write_some(
+                posix::fd const &s,
+                std::span<std::byte const> b,
+                std::chrono::nanoseconds timeout,
+                std::source_location const l = std::source_location::current()) {
+            return write_some(s.native_handle(), b, deadline_from(timeout), l);
         }
 
         /// ### Socket APIs
@@ -160,82 +182,130 @@ namespace felspar::io {
 
         iop<socket_descriptor>
                 accept(socket_descriptor fd,
-                       std::optional<std::chrono::nanoseconds> timeout = {},
+                       std::optional<deadline> deadline = {},
                        std::source_location const loc =
                                std::source_location::current()) {
-            return do_accept(
-                    fd,
-                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                            : std::nullopt,
-                    loc);
+            return do_accept(fd, deadline, loc);
+        }
+        iop<socket_descriptor>
+                accept(socket_descriptor fd,
+                       std::chrono::nanoseconds timeout,
+                       std::source_location const loc =
+                               std::source_location::current()) {
+            return accept(fd, deadline_from(timeout), loc);
         }
         iop<socket_descriptor>
                 accept(posix::fd const &sock,
-                       std::optional<std::chrono::nanoseconds> timeout = {},
+                       std::optional<deadline> deadline = {},
                        std::source_location const loc =
                                std::source_location::current()) {
-            return accept(sock.native_handle(), timeout, loc);
+            return accept(sock.native_handle(), deadline, loc);
+        }
+        iop<socket_descriptor>
+                accept(posix::fd const &sock,
+                       std::chrono::nanoseconds timeout,
+                       std::source_location const loc =
+                               std::source_location::current()) {
+            return accept(sock.native_handle(), deadline_from(timeout), loc);
         }
         iop<void>
                 connect(socket_descriptor fd,
                         sockaddr const *addr,
                         socklen_t addrlen,
-                        std::optional<std::chrono::nanoseconds> timeout = {},
+                        std::optional<deadline> deadline = {},
                         std::source_location const loc =
                                 std::source_location::current()) {
-            return do_connect(
-                    fd, addr, addrlen,
-                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                            : std::nullopt,
-                    loc);
+            return do_connect(fd, addr, addrlen, deadline, loc);
+        }
+        iop<void>
+                connect(socket_descriptor fd,
+                        sockaddr const *addr,
+                        socklen_t addrlen,
+                        std::chrono::nanoseconds timeout,
+                        std::source_location const loc =
+                                std::source_location::current()) {
+            return connect(fd, addr, addrlen, deadline_from(timeout), loc);
         }
         iop<void>
                 connect(posix::fd const &sock,
                         sockaddr const *addr,
                         socklen_t addrlen,
-                        std::optional<std::chrono::nanoseconds> timeout = {},
+                        std::optional<deadline> deadline = {},
                         std::source_location const loc =
                                 std::source_location::current()) {
-            return connect(sock.native_handle(), addr, addrlen, timeout, loc);
+            return connect(sock.native_handle(), addr, addrlen, deadline, loc);
+        }
+        iop<void>
+                connect(posix::fd const &sock,
+                        sockaddr const *addr,
+                        socklen_t addrlen,
+                        std::chrono::nanoseconds timeout,
+                        std::source_location const loc =
+                                std::source_location::current()) {
+            return connect(
+                    sock.native_handle(), addr, addrlen, deadline_from(timeout),
+                    loc);
         }
 
 
         /// ### File readiness
         iop<void> read_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_read_ready(
-                    fd,
-                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                            : std::nullopt,
-                    loc);
+            return do_read_ready(fd, deadline, loc);
+        }
+        iop<void> read_ready(
+                socket_descriptor fd,
+                std::chrono::nanoseconds timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return read_ready(fd, deadline_from(timeout), loc);
         }
         iop<void> read_ready(
                 posix::fd const &sock,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return read_ready(sock.native_handle(), timeout, loc);
+            return read_ready(sock.native_handle(), deadline, loc);
+        }
+        iop<void> read_ready(
+                posix::fd const &sock,
+                std::chrono::nanoseconds timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return read_ready(
+                    sock.native_handle(), deadline_from(timeout), loc);
         }
         iop<void> write_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return do_write_ready(
-                    fd,
-                    timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                            : std::nullopt,
-                    loc);
+            return do_write_ready(fd, deadline, loc);
+        }
+        iop<void> write_ready(
+                socket_descriptor fd,
+                std::chrono::nanoseconds timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return write_ready(fd, deadline_from(timeout), loc);
         }
         iop<void> write_ready(
                 posix::fd const &sock,
-                std::optional<std::chrono::nanoseconds> timeout = {},
+                std::optional<deadline> deadline = {},
                 std::source_location const loc =
                         std::source_location::current()) {
-            return write_ready(sock.native_handle(), timeout, loc);
+            return write_ready(sock.native_handle(), deadline, loc);
+        }
+        iop<void> write_ready(
+                posix::fd const &sock,
+                std::chrono::nanoseconds timeout,
+                std::source_location const loc =
+                        std::source_location::current()) {
+            return write_ready(
+                    sock.native_handle(), deadline_from(timeout), loc);
         }
 
       private:

--- a/include/felspar/io/warden.poll.hpp
+++ b/include/felspar/io/warden.poll.hpp
@@ -60,12 +60,12 @@ namespace felspar::io {
         iop<std::size_t> do_read_some(
                 socket_descriptor fd,
                 std::span<std::byte>,
-                std::optional<std::chrono::nanoseconds>,
+                std::optional<deadline>,
                 std::source_location) override;
         iop<std::size_t> do_write_some(
                 socket_descriptor fd,
                 std::span<std::byte const>,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
 
         /// ### Sockets
@@ -73,23 +73,23 @@ namespace felspar::io {
                 socket_descriptor sock, std::source_location) override;
         iop<socket_descriptor> do_accept(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
         iop<void> do_connect(
                 socket_descriptor fd,
                 sockaddr const *,
                 socklen_t,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
 
         /// ### File descriptor readiness
         iop<void> do_read_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
         iop<void> do_write_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
 
 

--- a/include/felspar/io/warden.uring.hpp
+++ b/include/felspar/io/warden.uring.hpp
@@ -43,34 +43,34 @@ namespace felspar::io {
         iop<std::size_t> do_read_some(
                 socket_descriptor fd,
                 std::span<std::byte>,
-                std::optional<std::chrono::nanoseconds>,
+                std::optional<deadline>,
                 std::source_location) override;
         iop<std::size_t> do_write_some(
                 socket_descriptor fd,
                 std::span<std::byte const>,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
 
         /// Sockets
         iop<socket_descriptor> do_accept(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
         iop<void> do_connect(
                 socket_descriptor fd,
                 sockaddr const *,
                 socklen_t,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
 
         /// File descriptor readiness
         iop<void> do_read_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
         iop<void> do_write_ready(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location) override;
     };
 

--- a/include/felspar/io/write.hpp
+++ b/include/felspar/io/write.hpp
@@ -21,7 +21,11 @@ namespace felspar::io {
             std::span<std::byte const> const s,
             std::optional<std::chrono::nanoseconds> const timeout = {},
             std::source_location const loc = std::source_location::current()) {
-        return w.write_some(sock, s, timeout, loc);
+        return w.write_some(
+                sock, s,
+                timeout ? std::optional<deadline>{deadline_from(*timeout)}
+                        : std::nullopt,
+                loc);
     }
 
 

--- a/include/felspar/io/write.hpp
+++ b/include/felspar/io/write.hpp
@@ -19,13 +19,18 @@ namespace felspar::io {
             warden &w,
             S &&sock,
             std::span<std::byte const> const s,
-            std::optional<std::chrono::nanoseconds> const timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
-        return w.write_some(
-                sock, s,
-                timeout ? std::optional<deadline>{deadline_from(*timeout)}
-                        : std::nullopt,
-                loc);
+        return w.write_some(sock, s, deadline, loc);
+    }
+    template<typename S>
+    inline auto write_some(
+            warden &w,
+            S &&sock,
+            std::span<std::byte const> const s,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return w.write_some(sock, s, deadline_from(timeout), loc);
     }
 
 
@@ -43,12 +48,12 @@ namespace felspar::io {
             warden &ward,
             S &&sock,
             std::span<std::byte const> const s,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         auto out{s};
         while (out.size()) {
             auto const bytes =
-                    co_await write_some(ward, sock, out, timeout, loc);
+                    co_await write_some(ward, sock, out, deadline, loc);
             /// TODO This calculation for written bytes looks suspiciously wrong
             if (not bytes) { co_return s.size() - out.size(); }
             out = out.subspan(bytes);
@@ -57,43 +62,93 @@ namespace felspar::io {
     }
     template<typename S>
     FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
+            warden &ward,
+            S &&sock,
+            std::span<std::byte const> const s,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return write_all(
+                ward, std::forward<S>(sock), s, deadline_from(timeout), loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
             warden &w,
             S &&fd,
             void const *buf,
             std::size_t count,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         return write_all(
                 w, std::forward<S>(fd),
                 std::span<std::byte const>{
                         reinterpret_cast<std::byte const *>(buf), count},
-                std::move(timeout), loc);
+                deadline, loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
+            warden &w,
+            S &&fd,
+            void const *buf,
+            std::size_t count,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return write_all(
+                w, std::forward<S>(fd),
+                std::span<std::byte const>{
+                        reinterpret_cast<std::byte const *>(buf), count},
+                deadline_from(timeout), loc);
     }
     template<typename S>
     FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
             warden &w,
             S &&fd,
             std::span<std::uint8_t const> s,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         return write_all(
                 w, std::forward<S>(fd),
                 std::span<std::byte const>{
                         reinterpret_cast<std::byte const *>(s.data()), s.size()},
-                std::move(timeout), loc);
+                deadline, loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
+            warden &w,
+            S &&fd,
+            std::span<std::uint8_t const> s,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return write_all(
+                w, std::forward<S>(fd),
+                std::span<std::byte const>{
+                        reinterpret_cast<std::byte const *>(s.data()), s.size()},
+                deadline_from(timeout), loc);
     }
     template<typename S>
     FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
             warden &w,
             S &&fd,
             std::string_view s,
-            std::optional<std::chrono::nanoseconds> timeout = {},
+            std::optional<deadline> deadline = {},
             std::source_location const loc = std::source_location::current()) {
         return write_all(
                 w, std::forward<S>(fd),
                 std::span<std::byte const>{
                         reinterpret_cast<std::byte const *>(s.data()), s.size()},
-                std::move(timeout), loc);
+                deadline, loc);
+    }
+    template<typename S>
+    FELSPAR_CORO_WRAPPER inline warden::task<std::size_t> write_all(
+            warden &w,
+            S &&fd,
+            std::string_view s,
+            std::chrono::nanoseconds const timeout,
+            std::source_location const loc = std::source_location::current()) {
+        return write_all(
+                w, std::forward<S>(fd),
+                std::span<std::byte const>{
+                        reinterpret_cast<std::byte const *>(s.data()), s.size()},
+                deadline_from(timeout), loc);
     }
 
 

--- a/roadmap-deadlines.md
+++ b/roadmap-deadlines.md
@@ -23,17 +23,17 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 ### Chunk 1.2: Convert the `do_*` IOP virtuals and completions to deadlines
 
 **Tests:**
-* [ ] Existing timeout regression tests stay green: `timers` (`write/poll`, `accept/poll`, and the io_uring variants) and `connect` in `test/run/timers.cpp` / `test/run/timers.connect.cpp`.
-* [ ] Existing `test/run/cancel.cpp` stays green (verifies IOP destruction/cancel still cancels timeouts).
+* [x] Existing timeout regression tests stay green: `timers` (`write/poll`, `accept/poll`, and the io_uring variants) and `connect` in `test/run/timers.cpp` / `test/run/timers.connect.cpp`.
+* [x] Existing `test/run/cancel.cpp` stays green (verifies IOP destruction/cancel still cancels timeouts).
 
 **Implementation:**
-* [ ] In `include/felspar/io/warden.hpp` change the protected virtuals `do_read_some`, `do_write_some`, `do_accept`, `do_connect`, `do_read_ready`, `do_write_ready` to take `std::optional<deadline>` instead of `std::optional<std::chrono::nanoseconds>`. Keep `do_close` (no timeout) and `do_sleep` (handled in 1.4) unchanged.
-* [ ] Update the public warden timeout methods to convert inline before calling the `do_*` virtual (no new public overload yet). These methods still take `std::optional<std::chrono::nanoseconds>` at this stage, so guard the conversion: `timeout ? std::optional<deadline>{deadline_from(*timeout)} : std::nullopt`. (Once Chunk 1.3 makes the timeout overload a plain `std::chrono::nanoseconds`, this collapses to a bare `deadline_from(timeout)`.)
-* [ ] `src/poll.hpp`: rename the completion's `timeout` field to `deadline` (type `std::optional<deadline>`); `insert_timeout()` inserts the stored deadline directly into `self->timeouts` (drop the `now() + *timeout` calculation — the multimap is already deadline-keyed).
-* [ ] `src/uring.hpp`: store `std::optional<deadline>` in both `completion<R>` and `completion<void>`; in `setup_timeout()` compute the link-timeout `kts` from `*deadline - std::chrono::steady_clock::now()` (clamp negative to zero so an already-passed deadline fires immediately).
-* [ ] Update completion constructors/`do_*` definitions in `src/poll.iops.cpp` and `src/uring.iops.cpp` to pass the deadline through; `sleep_completion` constructs its base with `now() + ns` for now; `close_completion` keeps `{}`.
-* [ ] Update the forwarding overrides in `include/felspar/io/allocator.hpp` to the new `std::optional<deadline>` signatures.
-* [ ] Update the override declarations in `include/felspar/io/warden.poll.hpp` and `include/felspar/io/warden.uring.hpp`.
+* [x] In `include/felspar/io/warden.hpp` change the protected virtuals `do_read_some`, `do_write_some`, `do_accept`, `do_connect`, `do_read_ready`, `do_write_ready` to take `std::optional<deadline>` instead of `std::optional<std::chrono::nanoseconds>`. Keep `do_close` (no timeout) and `do_sleep` (handled in 1.4) unchanged.
+* [x] Update the public warden timeout methods to convert inline before calling the `do_*` virtual (no new public overload yet). These methods still take `std::optional<std::chrono::nanoseconds>` at this stage, so guard the conversion: `timeout ? std::optional<deadline>{deadline_from(*timeout)} : std::nullopt`. (Once Chunk 1.3 makes the timeout overload a plain `std::chrono::nanoseconds`, this collapses to a bare `deadline_from(timeout)`.)
+* [x] `src/poll.hpp`: rename the completion's `timeout` field to `deadline` (type `std::optional<deadline>`); `insert_timeout()` inserts the stored deadline directly into `self->timeouts` (drop the `now() + *timeout` calculation — the multimap is already deadline-keyed).
+* [x] `src/uring.hpp`: store `std::optional<deadline>` in both `completion<R>` and `completion<void>`; in `setup_timeout()` compute the link-timeout `kts` from `*deadline - std::chrono::steady_clock::now()` (clamp negative to zero so an already-passed deadline fires immediately).
+* [x] Update completion constructors/`do_*` definitions in `src/poll.iops.cpp` and `src/uring.iops.cpp` to pass the deadline through; `sleep_completion` constructs its base with `now() + ns` for now; `close_completion` keeps `{}`.
+* [x] Update the forwarding overrides in `include/felspar/io/allocator.hpp` to the new `std::optional<deadline>` signatures.
+* [x] Update the override declarations in `include/felspar/io/warden.poll.hpp` and `include/felspar/io/warden.uring.hpp`.
 
 ---
 

--- a/roadmap-deadlines.md
+++ b/roadmap-deadlines.md
@@ -10,14 +10,13 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 ### Chunk 1.1: Introduce the `deadline` type and conversion helper
 
 **Tests:**
-* [ ] Add `test/headers/deadline.cpp` (single `#include`) to the header-compile test list in `test/headers/CMakeLists.txt`.
-* [ ] Unit test (new `test/run/deadline.cpp`, registered in `test/run/CMakeLists.txt`): `deadline_from(std::nullopt)` returns `std::nullopt`.
-* [ ] Unit test: `deadline_from(20ms)` returns a time point in `[now+19ms, now+21ms]` (mirrors the jitter tolerance style in `test/run/timers.cpp`).
+* [x] Add `test/headers/deadline.cpp` (single `#include`) to the header-compile test list in `test/headers/CMakeLists.txt`.
+* [x] Unit test (new `test/run/deadline.cpp`, registered in `test/run/CMakeLists.txt`): `deadline_from(20ms)` returns a time point in `[now+19ms, now+21ms]` (mirrors the jitter tolerance style in `test/run/timers.cpp`).
 
 **Implementation:**
-* [ ] New `include/felspar/io/deadline.hpp`: `using deadline = std::chrono::steady_clock::time_point;` and an inline `std::optional<deadline> deadline_from(std::optional<std::chrono::nanoseconds>)` that returns `now() + *timeout` when set, else `std::nullopt`.
-* [ ] Include `deadline.hpp` from `include/felspar/io/warden.hpp` so the type is visible everywhere.
-* [ ] Add `deadline.hpp` to `include/felspar/io.hpp`.
+* [x] New `include/felspar/io/deadline.hpp`: `using deadline = std::chrono::steady_clock::time_point;` and an inline `deadline deadline_from(std::chrono::nanoseconds timeout)` that returns `now() + timeout`. The helper takes a plain duration — absence ("no timeout") is never converted; it is represented by an empty `std::optional<deadline>` at the call site instead.
+* [x] Include `deadline.hpp` from `include/felspar/io/warden.hpp` so the type is visible everywhere.
+* [x] Add `deadline.hpp` to `include/felspar/io.hpp`.
 
 ---
 
@@ -29,7 +28,7 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 
 **Implementation:**
 * [ ] In `include/felspar/io/warden.hpp` change the protected virtuals `do_read_some`, `do_write_some`, `do_accept`, `do_connect`, `do_read_ready`, `do_write_ready` to take `std::optional<deadline>` instead of `std::optional<std::chrono::nanoseconds>`. Keep `do_close` (no timeout) and `do_sleep` (handled in 1.4) unchanged.
-* [ ] Update the public warden timeout methods to convert inline with `deadline_from(timeout)` before calling the `do_*` virtual (no new public overload yet).
+* [ ] Update the public warden timeout methods to convert inline before calling the `do_*` virtual (no new public overload yet). These methods still take `std::optional<std::chrono::nanoseconds>` at this stage, so guard the conversion: `timeout ? std::optional<deadline>{deadline_from(*timeout)} : std::nullopt`. (Once Chunk 1.3 makes the timeout overload a plain `std::chrono::nanoseconds`, this collapses to a bare `deadline_from(timeout)`.)
 * [ ] `src/poll.hpp`: rename the completion's `timeout` field to `deadline` (type `std::optional<deadline>`); `insert_timeout()` inserts the stored deadline directly into `self->timeouts` (drop the `now() + *timeout` calculation — the multimap is already deadline-keyed).
 * [ ] `src/uring.hpp`: store `std::optional<deadline>` in both `completion<R>` and `completion<void>`; in `setup_timeout()` compute the link-timeout `kts` from `*deadline - std::chrono::steady_clock::now()` (clamp negative to zero so an already-passed deadline fires immediately).
 * [ ] Update completion constructors/`do_*` definitions in `src/poll.iops.cpp` and `src/uring.iops.cpp` to pass the deadline through; `sleep_completion` constructs its base with `now() + ns` for now; `close_completion` keeps `{}`.

--- a/roadmap-deadlines.md
+++ b/roadmap-deadlines.md
@@ -87,11 +87,11 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 ### Chunk 2.2: `connect.hpp` deadline overloads and composed threading
 
 **Tests:**
-* [ ] New test: `connect`-by-hostname against a host resolving to multiple addresses with a short deadline fails within ≈ the deadline overall (mirrors `test/run/timers.connect.cpp`), rather than resetting the timeout per address.
+* [x] New test: `connect`-by-hostname against a host resolving to multiple addresses with a short deadline fails within ≈ the deadline overall (mirrors `test/run/timers.connect.cpp`), rather than resetting the timeout per address.
 
 **Implementation:**
-* [ ] In `include/felspar/io/connect.hpp` add `std::optional<deadline>` overloads of the templated `connect(sock, addr, addrlen, ...)` and the `connect(hostname, port, ...)` declaration, replacing the Chunk 1.3 `std::optional<std::chrono::nanoseconds>` shim with the canonical deadline + non-optional `nanoseconds` pair.
-* [ ] In `src/convenience.cpp` implement the `connect`-by-hostname deadline overload so the deadline is computed once and shared across the `addrinfo` attempt loop; the timeout overload delegates.
+* [x] In `include/felspar/io/connect.hpp` add `std::optional<deadline>` overloads of the templated `connect(sock, addr, addrlen, ...)` and the `connect(hostname, port, ...)` declaration, replacing the Chunk 1.3 `std::optional<std::chrono::nanoseconds>` shim with the canonical deadline + non-optional `nanoseconds` pair.
+* [x] In `src/convenience.cpp` implement the `connect`-by-hostname deadline overload so the deadline is computed once and shared across the `addrinfo` attempt loop; the timeout overload delegates.
 
 ---
 

--- a/roadmap-deadlines.md
+++ b/roadmap-deadlines.md
@@ -1,0 +1,122 @@
+# Roadmap: Deadline-based lower-level IO APIs
+
+## Context
+Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` timeout, and composed operations (e.g. `read_exactly`, `write_all`, `connect`-by-hostname, `tls::connect`) pass that same timeout to each sub-operation — so the effective timeout resets on every retry and is effectively unbounded. We will give every timed API both a **deadline** overload and a **timeout** overload. The **deadline** overload is the canonical one: it takes `std::optional<std::chrono::steady_clock::time_point>` and carries the `= {}` default (so a no-argument call means "no deadline / run forever"). The **timeout** overload takes a plain `std::chrono::nanoseconds` (no `std::optional`, no default — you only pass a timeout when you actually have one), converts it to a deadline *immediately* on entry, and delegates. A single deadline is then threaded through composed operations so the user-supplied timeout bounds the whole operation.
+
+---
+
+## Phase 1: Deadline foundation and warden core — the warden speaks deadlines internally, timeout overloads delegate, all existing behaviour preserved
+
+### Chunk 1.1: Introduce the `deadline` type and conversion helper
+
+**Tests:**
+* [ ] Add `test/headers/deadline.cpp` (single `#include`) to the header-compile test list in `test/headers/CMakeLists.txt`.
+* [ ] Unit test (new `test/run/deadline.cpp`, registered in `test/run/CMakeLists.txt`): `deadline_from(std::nullopt)` returns `std::nullopt`.
+* [ ] Unit test: `deadline_from(20ms)` returns a time point in `[now+19ms, now+21ms]` (mirrors the jitter tolerance style in `test/run/timers.cpp`).
+
+**Implementation:**
+* [ ] New `include/felspar/io/deadline.hpp`: `using deadline = std::chrono::steady_clock::time_point;` and an inline `std::optional<deadline> deadline_from(std::optional<std::chrono::nanoseconds>)` that returns `now() + *timeout` when set, else `std::nullopt`.
+* [ ] Include `deadline.hpp` from `include/felspar/io/warden.hpp` so the type is visible everywhere.
+* [ ] Add `deadline.hpp` to `include/felspar/io.hpp`.
+
+---
+
+### Chunk 1.2: Convert the `do_*` IOP virtuals and completions to deadlines
+
+**Tests:**
+* [ ] Existing timeout regression tests stay green: `timers` (`write/poll`, `accept/poll`, and the io_uring variants) and `connect` in `test/run/timers.cpp` / `test/run/timers.connect.cpp`.
+* [ ] Existing `test/run/cancel.cpp` stays green (verifies IOP destruction/cancel still cancels timeouts).
+
+**Implementation:**
+* [ ] In `include/felspar/io/warden.hpp` change the protected virtuals `do_read_some`, `do_write_some`, `do_accept`, `do_connect`, `do_read_ready`, `do_write_ready` to take `std::optional<deadline>` instead of `std::optional<std::chrono::nanoseconds>`. Keep `do_close` (no timeout) and `do_sleep` (handled in 1.4) unchanged.
+* [ ] Update the public warden timeout methods to convert inline with `deadline_from(timeout)` before calling the `do_*` virtual (no new public overload yet).
+* [ ] `src/poll.hpp`: rename the completion's `timeout` field to `deadline` (type `std::optional<deadline>`); `insert_timeout()` inserts the stored deadline directly into `self->timeouts` (drop the `now() + *timeout` calculation — the multimap is already deadline-keyed).
+* [ ] `src/uring.hpp`: store `std::optional<deadline>` in both `completion<R>` and `completion<void>`; in `setup_timeout()` compute the link-timeout `kts` from `*deadline - std::chrono::steady_clock::now()` (clamp negative to zero so an already-passed deadline fires immediately).
+* [ ] Update completion constructors/`do_*` definitions in `src/poll.iops.cpp` and `src/uring.iops.cpp` to pass the deadline through; `sleep_completion` constructs its base with `now() + ns` for now; `close_completion` keeps `{}`.
+* [ ] Update the forwarding overrides in `include/felspar/io/allocator.hpp` to the new `std::optional<deadline>` signatures.
+* [ ] Update the override declarations in `include/felspar/io/warden.poll.hpp` and `include/felspar/io/warden.uring.hpp`.
+
+---
+
+### Chunk 1.3: Add deadline overloads to the public warden IOP methods
+
+**Tests:**
+* [ ] New test (extend `test/run/timers.cpp`): `co_await ward.accept(fd, deadline)` with a deadline a few ms in the future throws `felspar::io::timeout`, for both `poll_warden` and `uring_warden`.
+* [ ] New test: a deadline already in the past (`steady_clock::now() - 1ms`) times out essentially immediately.
+
+**Implementation:**
+* [ ] In `include/felspar/io/warden.hpp`, for `read_some`, `write_some`, `accept`, `connect`, `read_ready`, `write_ready` (both the `socket_descriptor` and `posix::fd` variants), make the **deadline** overload canonical: `std::optional<deadline> = {}`, carrying the default. Calling the `do_*` virtual happens here.
+* [ ] Change each **timeout** overload to take a plain `std::chrono::nanoseconds` (drop the `std::optional` and the default); its body is `return <name>(fd, …, deadline_from(timeout), loc);`.
+* [ ] Fix the one public call site that passes an explicit `{}` ahead of a positional `source_location`: in `src/convenience.cpp` the streaming `accept` does `ward.accept(fd, {}, loc)` — change `{}` to an explicitly-typed `std::optional<deadline>{}` so it binds the deadline overload unambiguously (semantics unchanged — still "no timeout"). The internal `completion<void>{s, {}, loc}` constructors are single-type and need no change.
+
+---
+
+### Chunk 1.4: `sleep_until` deadline overload
+
+**Tests:**
+* [ ] New test (extend `test/run/timers.cpp`): `sleep_until(now() + 20ms)` sleeps roughly 20ms (same jitter window as the existing `short_sleep` test), for both wardens.
+
+**Implementation:**
+* [ ] In `include/felspar/io/warden.hpp` add `sleep_until(deadline, std::source_location)`; change `do_sleep` to take a `deadline`.
+* [ ] Make `sleep(std::chrono::nanoseconds ns)` compute `now() + ns` and delegate to `sleep_until`.
+* [ ] Update `do_sleep` in `warden.poll.hpp`/`warden.uring.hpp`/`allocator.hpp` and the definitions in `src/poll.iops.cpp` (store deadline directly) and `src/uring.iops.cpp` (`io_uring_prep_timeout` from `deadline - now()`).
+
+---
+
+## Phase 2: Deadline-consistent end-user APIs — composed operations bound the whole operation by a single deadline
+
+### Chunk 2.1: `read.hpp` deadline overloads and composed threading
+
+**Tests:**
+* [ ] New test (`test/run/`): a `read_exactly` that requires several partial reads from a slow/loopback pipe (pattern from `accept_writer`/`write_forever` in `test/run/timers.cpp`) with a single timeout times out after ≈ that timeout total — not N × timeout.
+* [ ] `read_until_lf_strip_cr` with a deadline times out across multiple `do_read_some` calls.
+
+**Implementation:**
+* [ ] In `include/felspar/io/read.hpp` add `std::optional<deadline>` overloads of the free `read_some`, `read_exactly` (all three signatures), `read_buffer::do_read_some`, and `read_until_lf_strip_cr`.
+* [ ] Each timeout overload converts once via `deadline_from` and delegates; the deadline overloads loop passing the *same* deadline to every inner call.
+
+---
+
+### Chunk 2.2: `write.hpp` deadline overloads and composed threading
+
+**Tests:**
+* [ ] New test: `write_all` to a blocked socket (extend the `write_forever` setup in `test/run/timers.cpp`) with one timeout bounds the entire write loop, not each `write_some`.
+
+**Implementation:**
+* [ ] In `include/felspar/io/write.hpp` add `std::optional<deadline>` overloads of the free `write_some` and all `write_all` signatures; timeout overloads convert once and delegate; `write_all`'s deadline overload threads the single deadline through the loop.
+
+---
+
+### Chunk 2.3: `connect.hpp` deadline overloads and composed threading
+
+**Tests:**
+* [ ] New test: `connect`-by-hostname against a host resolving to multiple addresses with a short deadline fails within ≈ the deadline overall (mirrors `test/run/timers.connect.cpp`), rather than resetting the timeout per address.
+
+**Implementation:**
+* [ ] In `include/felspar/io/connect.hpp` add `std::optional<deadline>` overloads of the templated `connect(sock, addr, addrlen, ...)` and the `connect(hostname, port, ...)` declaration.
+* [ ] In `src/convenience.cpp` implement the `connect`-by-hostname deadline overload so the deadline is computed once and shared across the `addrinfo` attempt loop; the timeout overload delegates.
+
+---
+
+### Chunk 2.4: `tls.hpp` deadline overloads and composed threading
+
+**Tests:**
+* [ ] Header test `test/headers/tls.cpp` still compiles with the new overloads.
+* [ ] Existing `test/run/tls.tests.cpp` stays green; if it already exercises a timeout, add a deadline-overload variant.
+
+**Implementation:**
+* [ ] In `include/felspar/io/tls.hpp` add `std::optional<deadline>` overloads of `tls::connect` (both forms), `tls::read_some`, `tls::write_some`, and the free-standing `read_some`/`write_some` wrappers.
+* [ ] In `src/tls.cpp` thread a single deadline through `service_operation`, `bio_read`, `bio_write`, and the `connect`-by-hostname `addrinfo` loop; timeout overloads convert once and delegate.
+
+---
+
+## Notes
+- **Backward compatibility is a hard constraint.** All of `examples/` and the existing test suite must compile unchanged. This holds because the **deadline** overload now carries the `= {}` default, so a no-argument call (e.g. `ward.connect(fd, addr, len)`) binds it with `nullopt` — exactly the old "no timeout" meaning. A call with a duration (e.g. `ward.accept(fd, 10ms)`) binds the **timeout** overload, and a call with a time point binds the deadline overload; `nanoseconds` and `steady_clock::time_point` are unrelated types so these never collide.
+- **The one ambiguous shape** is an explicit braced `{}` argument followed by a positional later argument: `{}` is viable for both `std::chrono::nanoseconds` (→ `0ns`) and `std::optional<deadline>` (→ `nullopt`). The only such public call site is the streaming `accept` in `src/convenience.cpp`; it is fixed in Chunk 1.3 by passing an explicitly-typed `std::optional<deadline>{}`. New code should avoid bare `{}` in the timeout/deadline slot.
+- **Why the timeout overload drops `std::optional`.** "No timeout" is now expressed by calling the deadline overload with no argument, so the timeout overload never needs to represent absence — a plain `std::chrono::nanoseconds` is sufficient and clearer at call sites.
+- **Conversion happens once, at entry.** Every timeout overload's first action is `deadline_from(timeout)`; it never passes a raw timeout downward. This is the single behavioural guarantee that makes composed timeouts consistent.
+- **Phase ordering.** Phase 1 is a behaviour-preserving internal refactor (shippable on its own — the warden simply speaks deadlines). The observable behavioural change lands in Phase 2, where composed operations stop resetting the timeout per sub-call. The Phase 2 chunks are mutually independent and can ship individually.
+- **uring timeouts** are recomputed as a relative `deadline - now()` timespec at submission time (clamped at zero), preserving current `io_uring_prep_link_timeout` semantics; switching to `IORING_TIMEOUT_ABS` against `CLOCK_MONOTONIC` is a possible later refinement but is out of scope here.
+- **Streaming `accept`** (`warden::stream<socket_descriptor>` in `accept.hpp`/`convenience.cpp`) is intentionally left timeout-free: a single deadline doesn't fit a long-lived generator, and a per-accept timeout is not a deadline. Single-shot `accept` on the warden gains both overloads in Phase 1.
+- The `allocator` warden (`include/felspar/io/allocator.hpp`) forwards every `do_*`, so it must be updated in lock-step whenever a virtual signature changes (Chunks 1.2 and 1.4).
+- Network-dependent tests (Chunks 2.3/2.4) will be as flaky as the existing `timers.connect.cpp`; prefer the deterministic loopback/pipe patterns from `timers.cpp` for the bounded-deadline assertions where possible.

--- a/roadmap-deadlines.md
+++ b/roadmap-deadlines.md
@@ -40,13 +40,14 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 ### Chunk 1.3: Add deadline overloads to the public warden IOP methods
 
 **Tests:**
-* [ ] New test (extend `test/run/timers.cpp`): `co_await ward.accept(fd, deadline)` with a deadline a few ms in the future throws `felspar::io::timeout`, for both `poll_warden` and `uring_warden`.
-* [ ] New test: a deadline already in the past (`steady_clock::now() - 1ms`) times out essentially immediately.
+* [x] New test (extend `test/run/timers.cpp`): `co_await ward.accept(fd, deadline)` with a deadline a few ms in the future throws `felspar::io::timeout`, for both `poll_warden` and `uring_warden`.
+* [x] New test: a deadline already in the past (`steady_clock::now() - 1ms`) times out essentially immediately.
 
 **Implementation:**
-* [ ] In `include/felspar/io/warden.hpp`, for `read_some`, `write_some`, `accept`, `connect`, `read_ready`, `write_ready` (both the `socket_descriptor` and `posix::fd` variants), make the **deadline** overload canonical: `std::optional<deadline> = {}`, carrying the default. Calling the `do_*` virtual happens here.
-* [ ] Change each **timeout** overload to take a plain `std::chrono::nanoseconds` (drop the `std::optional` and the default); its body is `return <name>(fd, …, deadline_from(timeout), loc);`.
-* [ ] Fix the one public call site that passes an explicit `{}` ahead of a positional `source_location`: in `src/convenience.cpp` the streaming `accept` does `ward.accept(fd, {}, loc)` — change `{}` to an explicitly-typed `std::optional<deadline>{}` so it binds the deadline overload unambiguously (semantics unchanged — still "no timeout"). The internal `completion<void>{s, {}, loc}` constructors are single-type and need no change.
+* [x] In `include/felspar/io/warden.hpp`, for `read_some`, `write_some`, `accept`, `connect`, `read_ready`, `write_ready` (both the `socket_descriptor` and `posix::fd` variants), make the **deadline** overload canonical: `std::optional<deadline> = {}`, carrying the default. Calling the `do_*` virtual happens here.
+* [x] Change each **timeout** overload to take a plain `std::chrono::nanoseconds` (drop the `std::optional` and the default); its body is `return <name>(fd, …, deadline_from(timeout), loc);`.
+* [x] Fix the one public call site that passes an explicit `{}` ahead of a positional `source_location`: in `src/convenience.cpp` the streaming `accept` does `ward.accept(fd, {}, loc)` — change `{}` to an explicitly-typed `std::optional<deadline>{}` so it binds the deadline overload unambiguously (semantics unchanged — still "no timeout"). The internal `completion<void>{s, {}, loc}` constructors are single-type and need no change.
+* [x] **Forced compile-fixes** (the warden no longer accepts `std::optional<std::chrono::nanoseconds>`, so every existing forwarder of an optional timeout must convert before calling the warden — these stay on their current single `std::optional<std::chrono::nanoseconds>` public signatures, the proper dual overloads land in Phase 2): the free-function forwarders in `include/felspar/io/read.hpp`, `write.hpp`, `connect.hpp` (plain `return`, safe), and the two `co_await` sites in `src/tls.cpp` (`bio_write` → `warden.read_some`, SNI `connect` → `warden.connect`). **GCC caveat:** the guarded ternary must NOT sit directly inside a `co_await` argument — GCC mis-sequences it and dereferences an empty optional under `_GLIBCXX_ASSERTIONS`; hoist it to a local first. See [[deadline-gcc-coroutine-ternary]].
 
 ---
 

--- a/roadmap-deadlines.md
+++ b/roadmap-deadlines.md
@@ -65,48 +65,33 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 
 ## Phase 2: Deadline-consistent end-user APIs — composed operations bound the whole operation by a single deadline
 
-### Chunk 2.1: `read.hpp` deadline overloads and composed threading
+### Chunk 2.1: `read.hpp`, `write.hpp` & TLS deadline overloads and composed threading
+
+> **Why these three are one chunk.** `test/run/tls.tests.cpp` instantiates `write_all` and `read_until_lf_strip_cr` over the `tls` type, and TLS's own `bio_read` calls `write_all`. So the leaf `read_some`/`write_some` (free functions *and* the `tls` members they forward to) must gain `std::optional<deadline>` overloads in the *same* step as the composed `write_all`/`read_exactly`/`read_until_lf_strip_cr` that start passing deadlines into them — otherwise the TLS test can't compile. Separating them would force transitional `std::optional<std::chrono::nanoseconds>` shims on every leaf. (`connect.hpp` is independent and stays its own chunk.)
 
 **Tests:**
-* [ ] New test (`test/run/`): a `read_exactly` that requires several partial reads from a slow/loopback pipe (pattern from `accept_writer`/`write_forever` in `test/run/timers.cpp`) with a single timeout times out after ≈ that timeout total — not N × timeout.
-* [ ] `read_until_lf_strip_cr` with a deadline times out across multiple `do_read_some` calls.
+* [x] New test (`test/run/`): a `read_exactly` that requires several partial reads from a slow/loopback pipe (pattern from `accept_writer`/`write_forever` in `test/run/timers.cpp`) with a single timeout times out after ≈ that timeout total — not N × timeout.
+* [x] `read_until_lf_strip_cr` with a deadline times out across multiple `do_read_some` calls.
+* [x] New test: `write_all` to a blocked socket (extend the `write_forever` setup in `test/run/timers.cpp`) with one timeout bounds the entire write loop, not each `write_some`.
+* [x] Header tests `test/headers/read.cpp`/`write.cpp`/`tls.cpp` still compile; existing `test/run/tls.tests.cpp` stays green.
 
 **Implementation:**
-* [ ] In `include/felspar/io/read.hpp` add `std::optional<deadline>` overloads of the free `read_some`, `read_exactly` (all three signatures), `read_buffer::do_read_some`, and `read_until_lf_strip_cr`.
-* [ ] Each timeout overload converts once via `deadline_from` and delegates; the deadline overloads loop passing the *same* deadline to every inner call.
+* [x] `include/felspar/io/read.hpp`: add `std::optional<deadline>` overloads of the free `read_some`, `read_exactly` (all three signatures), `read_buffer::do_read_some`, and `read_until_lf_strip_cr`. Composed overloads loop passing the *same* deadline to every inner call.
+* [x] `include/felspar/io/write.hpp`: add `std::optional<deadline>` overloads of the free `write_some` and all `write_all` signatures; `write_all`'s deadline overload threads the single deadline through the loop.
+* [x] `include/felspar/io/tls.hpp`: add `std::optional<deadline>` overloads of `tls::connect` (both forms), `tls::read_some`, `tls::write_some`, and the free-standing `read_some`/`write_some` wrappers.
+* [x] `src/tls.cpp`: thread a single deadline through `service_operation`, `bio_read` (→ `write_all(..., deadline, ...)`), `bio_write` (→ `warden.read_some(..., deadline, ...)`), and the `connect`-by-hostname `addrinfo` loop. Hoist any deadline conversion out of `co_await` arguments into a local first — see [[deadline-gcc-coroutine-ternary]].
+* [x] Across all four files, replace the transitional `std::optional<std::chrono::nanoseconds>` forwarder overloads left by Chunk 1.3 with the canonical pair: deadline overload (`std::optional<deadline> = {}`) + non-optional `std::chrono::nanoseconds` timeout overload. Safe to drop the optional shims here because every composed caller is converted in this same chunk.
 
 ---
 
-### Chunk 2.2: `write.hpp` deadline overloads and composed threading
-
-**Tests:**
-* [ ] New test: `write_all` to a blocked socket (extend the `write_forever` setup in `test/run/timers.cpp`) with one timeout bounds the entire write loop, not each `write_some`.
-
-**Implementation:**
-* [ ] In `include/felspar/io/write.hpp` add `std::optional<deadline>` overloads of the free `write_some` and all `write_all` signatures; timeout overloads convert once and delegate; `write_all`'s deadline overload threads the single deadline through the loop.
-
----
-
-### Chunk 2.3: `connect.hpp` deadline overloads and composed threading
+### Chunk 2.2: `connect.hpp` deadline overloads and composed threading
 
 **Tests:**
 * [ ] New test: `connect`-by-hostname against a host resolving to multiple addresses with a short deadline fails within ≈ the deadline overall (mirrors `test/run/timers.connect.cpp`), rather than resetting the timeout per address.
 
 **Implementation:**
-* [ ] In `include/felspar/io/connect.hpp` add `std::optional<deadline>` overloads of the templated `connect(sock, addr, addrlen, ...)` and the `connect(hostname, port, ...)` declaration.
+* [ ] In `include/felspar/io/connect.hpp` add `std::optional<deadline>` overloads of the templated `connect(sock, addr, addrlen, ...)` and the `connect(hostname, port, ...)` declaration, replacing the Chunk 1.3 `std::optional<std::chrono::nanoseconds>` shim with the canonical deadline + non-optional `nanoseconds` pair.
 * [ ] In `src/convenience.cpp` implement the `connect`-by-hostname deadline overload so the deadline is computed once and shared across the `addrinfo` attempt loop; the timeout overload delegates.
-
----
-
-### Chunk 2.4: `tls.hpp` deadline overloads and composed threading
-
-**Tests:**
-* [ ] Header test `test/headers/tls.cpp` still compiles with the new overloads.
-* [ ] Existing `test/run/tls.tests.cpp` stays green; if it already exercises a timeout, add a deadline-overload variant.
-
-**Implementation:**
-* [ ] In `include/felspar/io/tls.hpp` add `std::optional<deadline>` overloads of `tls::connect` (both forms), `tls::read_some`, `tls::write_some`, and the free-standing `read_some`/`write_some` wrappers.
-* [ ] In `src/tls.cpp` thread a single deadline through `service_operation`, `bio_read`, `bio_write`, and the `connect`-by-hostname `addrinfo` loop; timeout overloads convert once and delegate.
 
 ---
 
@@ -115,8 +100,9 @@ Every end-user API currently takes a `std::optional<std::chrono::nanoseconds>` t
 - **The one ambiguous shape** is an explicit braced `{}` argument followed by a positional later argument: `{}` is viable for both `std::chrono::nanoseconds` (→ `0ns`) and `std::optional<deadline>` (→ `nullopt`). The only such public call site is the streaming `accept` in `src/convenience.cpp`; it is fixed in Chunk 1.3 by passing an explicitly-typed `std::optional<deadline>{}`. New code should avoid bare `{}` in the timeout/deadline slot.
 - **Why the timeout overload drops `std::optional`.** "No timeout" is now expressed by calling the deadline overload with no argument, so the timeout overload never needs to represent absence — a plain `std::chrono::nanoseconds` is sufficient and clearer at call sites.
 - **Conversion happens once, at entry.** Every timeout overload's first action is `deadline_from(timeout)`; it never passes a raw timeout downward. This is the single behavioural guarantee that makes composed timeouts consistent.
-- **Phase ordering.** Phase 1 is a behaviour-preserving internal refactor (shippable on its own — the warden simply speaks deadlines). The observable behavioural change lands in Phase 2, where composed operations stop resetting the timeout per sub-call. The Phase 2 chunks are mutually independent and can ship individually.
+- **Phase ordering.** Phase 1 is a behaviour-preserving internal refactor (shippable on its own — the warden simply speaks deadlines). The observable behavioural change lands in Phase 2, where composed operations stop resetting the timeout per sub-call.
+- **Phase 2 cross-type instantiation dependency.** A composed template (`write_all`, `read_until_lf_strip_cr`, `read_exactly`) resolves its leaf `read_some`/`write_some` call against whatever type it is instantiated over. `test/run/tls.tests.cpp` instantiates them over `tls`, so the moment a composed op threads `std::optional<deadline>`, the `tls` leaf overloads must already accept it — and TLS's `bio_read` in turn calls `write_all`. That mutual dependency is why `read.hpp`/`write.hpp`/`tls` are converted in one chunk (2.1) rather than separately. `connect.hpp` (2.2) shares no leaf with that cluster and stays independent.
 - **uring timeouts** are recomputed as a relative `deadline - now()` timespec at submission time (clamped at zero), preserving current `io_uring_prep_link_timeout` semantics; switching to `IORING_TIMEOUT_ABS` against `CLOCK_MONOTONIC` is a possible later refinement but is out of scope here.
 - **Streaming `accept`** (`warden::stream<socket_descriptor>` in `accept.hpp`/`convenience.cpp`) is intentionally left timeout-free: a single deadline doesn't fit a long-lived generator, and a per-accept timeout is not a deadline. Single-shot `accept` on the warden gains both overloads in Phase 1.
 - The `allocator` warden (`include/felspar/io/allocator.hpp`) forwards every `do_*`, so it must be updated in lock-step whenever a virtual signature changes (Chunks 1.2 and 1.4).
-- Network-dependent tests (Chunks 2.3/2.4) will be as flaky as the existing `timers.connect.cpp`; prefer the deterministic loopback/pipe patterns from `timers.cpp` for the bounded-deadline assertions where possible.
+- Network-dependent tests (the TLS test in Chunk 2.1 and the `connect`-by-hostname test in Chunk 2.2) will be as flaky as the existing `timers.connect.cpp`; prefer the deterministic loopback/pipe patterns from `timers.cpp` for the bounded-deadline assertions where possible.

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # *felspar-io* Implementation
 
-The contains three implementations:
+There are three implementations that support the [Warden API](../include/felspar/io/warden.hpp):
 
 * POSIX using `poll`
 * Windows using `WSAPoll`

--- a/src/convenience.cpp
+++ b/src/convenience.cpp
@@ -24,7 +24,7 @@ felspar::io::warden::stream<felspar::io::socket_descriptor> felspar::io::accept(
      * before it can be used in this coroutine.
      */
     while (true) {
-        auto s = co_await ward.accept(fd, {}, loc);
+        auto s = co_await ward.accept(fd, std::optional<deadline>{}, loc);
 #if defined(FELSPAR_WINSOCK2)
         co_yield s;
 #else

--- a/src/convenience.cpp
+++ b/src/convenience.cpp
@@ -72,13 +72,13 @@ auto felspar::io::connect(
         warden &ward,
         char const *const hostname,
         std::uint16_t const port,
-        std::optional<std::chrono::nanoseconds> const timeout,
+        std::optional<deadline> const deadline,
         std::source_location const loc) -> warden::task<posix::fd> {
     std::exception_ptr eptr;
     for (auto host : addrinfo(hostname, port)) {
         try {
             auto fd = ward.create_socket(host.first->sa_family, SOCK_STREAM, 0);
-            co_await connect(ward, fd, host.first, host.second, timeout, loc);
+            co_await connect(ward, fd, host.first, host.second, deadline, loc);
             co_return fd;
         } catch (...) { eptr = std::current_exception(); }
     }
@@ -88,6 +88,16 @@ auto felspar::io::connect(
         throw felspar::stdexcept::runtime_error{
                 "No host found for " + std::string{hostname}, loc};
     }
+}
+
+
+auto felspar::io::connect(
+        warden &ward,
+        char const *const hostname,
+        std::uint16_t const port,
+        std::chrono::nanoseconds const timeout,
+        std::source_location const loc) -> warden::task<posix::fd> {
+    return connect(ward, hostname, port, deadline_from(timeout), loc);
 }
 
 

--- a/src/poll.hpp
+++ b/src/poll.hpp
@@ -18,24 +18,20 @@ namespace felspar::io {
     struct poll_warden::completion : public retrier, public io::completion<R> {
         completion(
                 poll_warden *w,
-                std::optional<std::chrono::nanoseconds> t,
+                std::optional<io::deadline> t,
                 std::source_location const loc)
-        : io::completion<R>{loc}, self{w}, timeout{t} {}
+        : io::completion<R>{loc}, self{w}, deadline{t} {}
 
         poll_warden *self;
         warden *ward() override { return self; }
 
-        std::optional<std::chrono::nanoseconds> timeout = {};
+        std::optional<io::deadline> deadline = {};
 
         void insert_timeout() {
-            if (timeout) {
-                auto const deadline =
-                        std::chrono::steady_clock::now() + *timeout;
-                self->timeouts.insert({deadline, this});
-            }
+            if (deadline) { self->timeouts.insert({*deadline, this}); }
         }
         void cancel_timeout() {
-            if (timeout) {
+            if (deadline) {
                 auto pos = std::find_if(
                         self->timeouts.begin(), self->timeouts.end(),
                         [this](auto const &s) { return s.second == this; });

--- a/src/poll.iops.cpp
+++ b/src/poll.iops.cpp
@@ -29,7 +29,7 @@ struct felspar::io::poll_warden::sleep_completion : public completion<void> {
             poll_warden *s,
             std::chrono::nanoseconds ns,
             std::source_location const loc)
-    : completion<void>{s, std::chrono::steady_clock::now() + ns, loc} {}
+    : completion<void>{s, deadline_from(ns), loc} {}
     void cancel_iop() override {}
     std::coroutine_handle<> iop_timedout() override {
         return io::completion<void>::handle;

--- a/src/poll.iops.cpp
+++ b/src/poll.iops.cpp
@@ -29,7 +29,7 @@ struct felspar::io::poll_warden::sleep_completion : public completion<void> {
             poll_warden *s,
             std::chrono::nanoseconds ns,
             std::source_location const loc)
-    : completion<void>{s, ns, loc} {}
+    : completion<void>{s, std::chrono::steady_clock::now() + ns, loc} {}
     void cancel_iop() override {}
     std::coroutine_handle<> iop_timedout() override {
         return io::completion<void>::handle;
@@ -50,7 +50,7 @@ public completion<std::size_t> {
             poll_warden *s,
             socket_descriptor f,
             std::span<std::byte> b,
-            std::optional<std::chrono::nanoseconds> timeout,
+            std::optional<io::deadline> timeout,
             std::source_location const loc)
     : completion<std::size_t>{s, timeout, loc}, fd{f}, buf{b} {}
     socket_descriptor fd;
@@ -78,7 +78,7 @@ public completion<std::size_t> {
 felspar::io::iop<std::size_t> felspar::io::poll_warden::do_read_some(
         socket_descriptor fd,
         std::span<std::byte> buf,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new read_some_completion{this, fd, buf, timeout, loc}};
 }
@@ -90,7 +90,7 @@ public completion<std::size_t> {
             poll_warden *s,
             socket_descriptor f,
             std::span<std::byte const> b,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<std::size_t>{s, t, loc}, fd{f}, buf{b} {}
     socket_descriptor fd;
@@ -120,7 +120,7 @@ public completion<std::size_t> {
 felspar::io::iop<std::size_t> felspar::io::poll_warden::do_write_some(
         socket_descriptor fd,
         std::span<std::byte const> buf,
-        std::optional<std::chrono::nanoseconds> t,
+        std::optional<deadline> t,
         std::source_location const loc) {
     return {new write_some_completion{this, fd, buf, t, loc}};
 }
@@ -131,7 +131,7 @@ public completion<socket_descriptor> {
     accept_completion(
             poll_warden *s,
             socket_descriptor f,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<socket_descriptor>{s, t, loc}, fd{f} {}
     socket_descriptor fd;
@@ -164,7 +164,7 @@ public completion<socket_descriptor> {
 felspar::io::iop<felspar::io::socket_descriptor>
         felspar::io::poll_warden::do_accept(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location const loc) {
     return {new accept_completion{this, fd, timeout, loc}};
 }
@@ -176,7 +176,7 @@ struct felspar::io::poll_warden::connect_completion : public completion<void> {
             socket_descriptor f,
             sockaddr const *a,
             socklen_t l,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<void>{s, t, loc}, fd{f}, addr{a}, addrlen{l} {}
     socket_descriptor fd;
@@ -244,7 +244,7 @@ felspar::io::iop<void> felspar::io::poll_warden::do_connect(
         socket_descriptor fd,
         sockaddr const *addr,
         socklen_t addrlen,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new connect_completion{this, fd, addr, addrlen, timeout, loc}};
 }
@@ -255,7 +255,7 @@ public completion<void> {
     read_ready_completion(
             poll_warden *s,
             socket_descriptor f,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<void>{s, t, loc}, fd{f} {}
     socket_descriptor fd;
@@ -272,7 +272,7 @@ public completion<void> {
 };
 felspar::io::iop<void> felspar::io::poll_warden::do_read_ready(
         socket_descriptor fd,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new read_ready_completion{this, fd, timeout, loc}};
 }
@@ -283,7 +283,7 @@ public completion<void> {
     write_ready_completion(
             poll_warden *s,
             socket_descriptor f,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<void>{s, t, loc}, fd{f} {}
     socket_descriptor fd;
@@ -301,7 +301,7 @@ public completion<void> {
 };
 felspar::io::iop<void> felspar::io::poll_warden::do_write_ready(
         socket_descriptor fd,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new write_ready_completion{this, fd, timeout, loc}};
 }

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -100,7 +100,10 @@ struct felspar::io::tls::impl {
             io::warden &warden,
             std::optional<std::chrono::nanoseconds> timeout,
             std::source_location const loc) {
-        auto const bytes = co_await warden.read_some(fd, buffer, timeout, loc);
+        std::optional<deadline> const dl = timeout
+                ? std::optional<deadline>{deadline_from(*timeout)}
+                : std::nullopt;
+        auto const bytes = co_await warden.read_some(fd, buffer, dl, loc);
         if (bytes == 0) {
             co_return 0;
         } else if (auto const written_int = BIO_write(nb, buffer.data(), bytes);
@@ -136,7 +139,10 @@ auto felspar::io::tls::connect(
         std::optional<std::chrono::nanoseconds> timeout,
         std::source_location const loc) -> warden::task<tls> {
     posix::fd fd = warden.create_socket(addr->sa_family, SOCK_STREAM, 0);
-    co_await warden.connect(fd, addr, addrlen, timeout, loc);
+    std::optional<deadline> const dl = timeout
+            ? std::optional<deadline>{deadline_from(*timeout)}
+            : std::nullopt;
+    co_await warden.connect(fd, addr, addrlen, dl, loc);
 
     auto i = std::make_unique<impl>(std::move(fd));
     SSL_set_tlsext_host_name(i->ssl, sni_hostname);

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -46,7 +46,7 @@ struct felspar::io::tls::impl {
     template<typename Op>
     io::warden::task<int> service_operation(
             io::warden &warden,
-            std::optional<std::chrono::nanoseconds> timeout,
+            std::optional<deadline> deadline,
             std::source_location const loc,
             Op &&op) {
         while (true) {
@@ -56,13 +56,13 @@ struct felspar::io::tls::impl {
             case SSL_ERROR_NONE: co_return result;
 
             case SSL_ERROR_WANT_READ:
-                co_await bio_read(warden, timeout, loc);
-                if (0 == co_await bio_write(warden, timeout, loc)) {
+                co_await bio_read(warden, deadline, loc);
+                if (0 == co_await bio_write(warden, deadline, loc)) {
                     co_return 0;
                 }
                 break;
             case SSL_ERROR_WANT_WRITE:
-                co_await bio_read(warden, timeout, loc);
+                co_await bio_read(warden, deadline, loc);
                 break;
 
             case SSL_ERROR_ZERO_RETURN: co_return 0;
@@ -76,7 +76,7 @@ struct felspar::io::tls::impl {
 
     io::warden::task<void> bio_read(
             io::warden &warden,
-            std::optional<std::chrono::nanoseconds> timeout,
+            std::optional<deadline> deadline,
             std::source_location const loc) {
         if (auto bytes = BIO_ctrl_pending(nb); bytes > buffer.size()) {
             throw felspar::stdexcept::logic_error{
@@ -92,18 +92,15 @@ struct felspar::io::tls::impl {
                         "Reading BIO read bytes mismatch"};
             } else {
                 co_await felspar::io::write_all(
-                        warden, fd, buffer.data(), bytes, timeout, loc);
+                        warden, fd, buffer.data(), bytes, deadline, loc);
             }
         }
     }
     io::warden::task<std::size_t> bio_write(
             io::warden &warden,
-            std::optional<std::chrono::nanoseconds> timeout,
+            std::optional<deadline> deadline,
             std::source_location const loc) {
-        std::optional<deadline> const dl = timeout
-                ? std::optional<deadline>{deadline_from(*timeout)}
-                : std::nullopt;
-        auto const bytes = co_await warden.read_some(fd, buffer, dl, loc);
+        auto const bytes = co_await warden.read_some(fd, buffer, deadline, loc);
         if (bytes == 0) {
             co_return 0;
         } else if (auto const written_int = BIO_write(nb, buffer.data(), bytes);
@@ -136,18 +133,15 @@ auto felspar::io::tls::connect(
         char const *const sni_hostname,
         sockaddr const *addr,
         socklen_t addrlen,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> deadline,
         std::source_location const loc) -> warden::task<tls> {
     posix::fd fd = warden.create_socket(addr->sa_family, SOCK_STREAM, 0);
-    std::optional<deadline> const dl = timeout
-            ? std::optional<deadline>{deadline_from(*timeout)}
-            : std::nullopt;
-    co_await warden.connect(fd, addr, addrlen, dl, loc);
+    co_await warden.connect(fd, addr, addrlen, deadline, loc);
 
     auto i = std::make_unique<impl>(std::move(fd));
     SSL_set_tlsext_host_name(i->ssl, sni_hostname);
     co_await i->service_operation(
-            warden, timeout, loc, [](impl &i) { return SSL_connect(i.ssl); });
+            warden, deadline, loc, [](impl &i) { return SSL_connect(i.ssl); });
 
     co_return tls{std::move(i)};
 }
@@ -155,13 +149,13 @@ auto felspar::io::tls::connect(
         warden &ward,
         char const *const hostname,
         std::uint16_t const port,
-        std::optional<std::chrono::nanoseconds> const timeout,
+        std::optional<deadline> const deadline,
         std::source_location const loc) -> warden::task<tls> {
     std::exception_ptr eptr;
     for (auto host : addrinfo(hostname, port)) {
         try {
             co_return co_await tls::connect(
-                    ward, hostname, host.first, host.second, timeout, loc);
+                    ward, hostname, host.first, host.second, deadline, loc);
         } catch (...) { eptr = std::current_exception(); }
     }
     if (eptr) {
@@ -176,10 +170,10 @@ auto felspar::io::tls::connect(
 auto felspar::io::tls::read_some(
         io::warden &warden,
         std::span<std::byte> const s,
-        std::optional<std::chrono::nanoseconds> const timeout,
+        std::optional<deadline> const deadline,
         std::source_location const loc) -> warden::task<std::size_t> {
     int const ret =
-            co_await p->service_operation(warden, timeout, loc, [s](impl &i) {
+            co_await p->service_operation(warden, deadline, loc, [s](impl &i) {
                 return SSL_read(i.ssl, s.data(), s.size());
             });
     if (ret < 0) {
@@ -194,10 +188,10 @@ auto felspar::io::tls::read_some(
 auto felspar::io::tls::write_some(
         io::warden &warden,
         std::span<std::byte const> const s,
-        std::optional<std::chrono::nanoseconds> const timeout,
+        std::optional<deadline> const deadline,
         std::source_location const loc) -> warden::task<std::size_t> {
     int const ret =
-            co_await p->service_operation(warden, timeout, loc, [s](impl &i) {
+            co_await p->service_operation(warden, deadline, loc, [s](impl &i) {
                 return SSL_write(i.ssl, s.data(), s.size());
             });
     if (ret <= 0) {

--- a/src/uring.hpp
+++ b/src/uring.hpp
@@ -47,14 +47,14 @@ namespace felspar::io {
             public io::completion<R> {
         completion(
                 uring_warden *w,
-                std::optional<std::chrono::nanoseconds> tout,
+                std::optional<io::deadline> tout,
                 std::source_location const loc)
-        : io::completion<R>{loc}, self{w}, timeout{tout} {}
+        : io::completion<R>{loc}, self{w}, deadline{tout} {}
 
         uring_warden *self = nullptr;
         warden *ward() override { return self; }
 
-        std::optional<std::chrono::nanoseconds> timeout = {};
+        std::optional<io::deadline> deadline = {};
         __kernel_timespec kts;
 
         ::io_uring_sqe *setup_submission(std::coroutine_handle<> h) {
@@ -63,11 +63,16 @@ namespace felspar::io {
         }
         std::coroutine_handle<> setup_timeout(::io_uring_sqe *sqe) {
             ::io_uring_sqe_set_data(sqe, this);
-            if (timeout) {
+            if (deadline) {
                 sqe->flags |= IOSQE_IO_LINK;
                 auto tsqe = self->ring->next_sqe();
+                auto const remaining =
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                *deadline - std::chrono::steady_clock::now());
                 kts.tv_sec = 0;
-                kts.tv_nsec = timeout->count();
+                kts.tv_nsec = remaining > std::chrono::nanoseconds::zero()
+                        ? remaining.count()
+                        : 0;
                 ::io_uring_prep_link_timeout(tsqe, &kts, 0);
                 ::io_uring_sqe_set_data(tsqe, this);
                 iop_count = 2;
@@ -77,7 +82,7 @@ namespace felspar::io {
 
         void deliver(int result) override {
             if (result < 0) {
-                if (timeout and result == -ECANCELED) {
+                if (deadline and result == -ECANCELED) {
                     /// This is the cancelled IOP so we ignore it as we've timed
                     /// out
                     return;
@@ -108,14 +113,14 @@ namespace felspar::io {
             public io::completion<void> {
         completion(
                 uring_warden *w,
-                std::optional<std::chrono::nanoseconds> tout,
+                std::optional<io::deadline> tout,
                 std::source_location const loc)
-        : io::completion<void>{loc}, self{w}, timeout{tout} {}
+        : io::completion<void>{loc}, self{w}, deadline{tout} {}
 
         uring_warden *self;
         warden *ward() override { return self; }
 
-        std::optional<std::chrono::nanoseconds> timeout = {};
+        std::optional<io::deadline> deadline = {};
         __kernel_timespec kts;
 
         ::io_uring_sqe *setup_submission(std::coroutine_handle<> h) {
@@ -124,11 +129,16 @@ namespace felspar::io {
         }
         std::coroutine_handle<> setup_timeout(::io_uring_sqe *sqe) {
             ::io_uring_sqe_set_data(sqe, this);
-            if (timeout) {
+            if (deadline) {
                 sqe->flags |= IOSQE_IO_LINK;
                 auto tsqe = self->ring->next_sqe();
+                auto const remaining =
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                *deadline - std::chrono::steady_clock::now());
                 kts.tv_sec = 0;
-                kts.tv_nsec = timeout->count();
+                kts.tv_nsec = remaining > std::chrono::nanoseconds::zero()
+                        ? remaining.count()
+                        : 0;
                 ::io_uring_prep_link_timeout(tsqe, &kts, 0);
                 ::io_uring_sqe_set_data(tsqe, this);
                 iop_count = 2;
@@ -140,7 +150,7 @@ namespace felspar::io {
             if (result == -ETIME) {
                 io::completion<void>::result = {
                         {ETIME, std::system_category()}, "uring IOP timeout"};
-            } else if (timeout and result == -ECANCELED) {
+            } else if (deadline and result == -ECANCELED) {
                 /// This is the cancelled IOP so we ignore it as we've timed
                 /// out
                 return;

--- a/src/uring.iops.cpp
+++ b/src/uring.iops.cpp
@@ -51,7 +51,7 @@ public completion<std::size_t> {
             uring_warden *s,
             int f,
             std::span<std::byte> b,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<std::size_t>{s, t, loc}, fd{f}, bytes{b} {}
     int fd;
@@ -65,7 +65,7 @@ public completion<std::size_t> {
 felspar::io::iop<std::size_t> felspar::io::uring_warden::do_read_some(
         socket_descriptor fd,
         std::span<std::byte> b,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new read_some_completion{this, fd, b, timeout, loc}};
 }
@@ -77,7 +77,7 @@ public completion<std::size_t> {
             uring_warden *s,
             socket_descriptor f,
             std::span<std::byte const> b,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<std::size_t>{s, t, loc}, fd{f}, bytes{b} {}
     socket_descriptor fd;
@@ -91,7 +91,7 @@ public completion<std::size_t> {
 felspar::io::iop<std::size_t> felspar::io::uring_warden::do_write_some(
         socket_descriptor fd,
         std::span<std::byte const> b,
-        std::optional<std::chrono::nanoseconds> t,
+        std::optional<deadline> t,
         std::source_location const loc) {
     return {new write_some_completion{this, fd, b, t, loc}};
 }
@@ -102,7 +102,7 @@ public completion<socket_descriptor> {
     accept_completion(
             uring_warden *s,
             socket_descriptor f,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<socket_descriptor>{s, t, loc}, fd{f} {}
     socket_descriptor fd = {};
@@ -117,7 +117,7 @@ public completion<socket_descriptor> {
 felspar::io::iop<felspar::io::socket_descriptor>
         felspar::io::uring_warden::do_accept(
                 socket_descriptor fd,
-                std::optional<std::chrono::nanoseconds> timeout,
+                std::optional<deadline> timeout,
                 std::source_location const loc) {
     return {new accept_completion{this, fd, timeout, loc}};
 }
@@ -129,7 +129,7 @@ struct felspar::io::uring_warden::connect_completion : public completion<void> {
             socket_descriptor f,
             sockaddr const *a,
             socklen_t l,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<void>{s, t, loc}, fd{f}, addr{a}, addrlen{l} {}
     socket_descriptor fd = {};
@@ -145,7 +145,7 @@ felspar::io::iop<void> felspar::io::uring_warden::do_connect(
         socket_descriptor fd,
         sockaddr const *addr,
         socklen_t addrlen,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new connect_completion{this, fd, addr, addrlen, timeout, loc}};
 }
@@ -156,7 +156,7 @@ struct felspar::io::uring_warden::poll_completion : public completion<void> {
             uring_warden *s,
             socket_descriptor f,
             short m,
-            std::optional<std::chrono::nanoseconds> t,
+            std::optional<io::deadline> t,
             std::source_location const loc)
     : completion<void>{s, t, loc}, fd{f}, mask{m} {}
     socket_descriptor fd = {};
@@ -169,13 +169,13 @@ struct felspar::io::uring_warden::poll_completion : public completion<void> {
 };
 felspar::io::iop<void> felspar::io::uring_warden::do_read_ready(
         socket_descriptor fd,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new poll_completion{this, fd, POLLIN, timeout, loc}};
 }
 felspar::io::iop<void> felspar::io::uring_warden::do_write_ready(
         socket_descriptor fd,
-        std::optional<std::chrono::nanoseconds> timeout,
+        std::optional<deadline> timeout,
         std::source_location const loc) {
     return {new poll_completion{this, fd, POLLOUT, timeout, loc}};
 }

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -5,6 +5,7 @@ if(TARGET felspar-check)
             accept.cpp
             completion.cpp
             connect.cpp
+            deadline.cpp
             error.cpp
             exceptions.cpp
             io.cpp

--- a/test/headers/deadline.cpp
+++ b/test/headers/deadline.cpp
@@ -1,0 +1,1 @@
+#include <felspar/io/deadline.hpp>

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -3,6 +3,7 @@ if(TARGET felspar-check)
             allocators.cpp
             basics.cpp
             cancel.cpp
+            deadline.cpp
             exceptions.cpp
             pipe.cpp
             run_batch.cpp

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -4,6 +4,7 @@ if(TARGET felspar-check)
             basics.cpp
             cancel.cpp
             deadline.cpp
+            deadline.composed.cpp
             exceptions.cpp
             pipe.cpp
             run_batch.cpp

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -13,6 +13,7 @@ if(TARGET felspar-check)
 endif()
 if(TARGET felspar-stress)
     add_test_run(felspar-stress felspar-io-openssl TESTS
+            deadline.connect.cpp
             timers.connect.cpp
             tls.tests.cpp
         )

--- a/test/run/deadline.composed.cpp
+++ b/test/run/deadline.composed.cpp
@@ -1,0 +1,103 @@
+#include <felspar/io.hpp>
+#include <felspar/test.hpp>
+
+
+using namespace std::literals;
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("deadline/composed");
+
+
+    /**
+     * Drip non-LF bytes one at a time so a composed read is forced to make many
+     * partial `read_some` calls before its deadline is reached. The stream
+     * never ends and never contains a newline.
+     */
+    felspar::io::warden::task<void> drip_writer(
+            felspar::io::warden &ward, felspar::posix::fd &write_end) {
+        std::array<std::byte, 1> byte{std::byte{'x'}};
+        while (true) {
+            co_await ward.sleep(5ms);
+            co_await felspar::io::write_all(
+                    ward, write_end, std::span<std::byte const>{byte});
+        }
+    }
+
+
+    /**
+     * `read_exactly` must time out about one deadline after it starts even
+     * though bytes keep arriving -- the single deadline bounds the whole
+     * operation, not each `read_some`.
+     */
+    felspar::io::warden::task<void>
+            read_exactly_deadline(felspar::io::warden &ward) {
+        felspar::test::injected check;
+
+        auto pipe = ward.create_pipe();
+        felspar::io::warden::starter<void> start;
+        start.post(drip_writer, std::ref(ward), std::ref(pipe.write));
+
+        std::array<std::byte, 128> buffer{};
+        auto const begin = std::chrono::steady_clock::now();
+        try {
+            co_await felspar::io::read_exactly(ward, pipe.read, buffer, 50ms);
+            check(false) == true;
+        } catch (felspar::io::timeout const &) {
+            check(true) == true;
+        } catch (...) { check(false) == true; }
+        auto const elapsed = std::chrono::steady_clock::now() - begin;
+        check(elapsed <= 300ms) == true;
+    }
+    auto const rep = suite.test("read-exactly-deadline/poll", []() {
+        felspar::io::poll_warden ward;
+        ward.run(read_exactly_deadline);
+    });
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const reu = suite.test("read-exactly-deadline/io_uring", []() {
+        felspar::io::uring_warden ward{5};
+        ward.run(read_exactly_deadline);
+    });
+#endif
+
+
+    /**
+     * `read_until_lf_strip_cr` never sees a newline so it keeps issuing
+     * `do_read_some` calls; the single deadline must still bound the whole line
+     * read across all of those partial reads.
+     */
+    felspar::io::warden::task<void>
+            read_until_deadline(felspar::io::warden &ward) {
+        felspar::test::injected check;
+
+        auto pipe = ward.create_pipe();
+        felspar::io::warden::starter<void> start;
+        start.post(drip_writer, std::ref(ward), std::ref(pipe.write));
+
+        felspar::io::read_buffer<std::array<char, 1 << 10>> buffer;
+        auto const begin = std::chrono::steady_clock::now();
+        try {
+            co_await felspar::io::read_until_lf_strip_cr(
+                    ward, pipe.read, buffer, 50ms);
+            check(false) == true;
+        } catch (felspar::io::timeout const &) {
+            check(true) == true;
+        } catch (...) { check(false) == true; }
+        auto const elapsed = std::chrono::steady_clock::now() - begin;
+        check(elapsed <= 300ms) == true;
+    }
+    auto const rup = suite.test("read-until-deadline/poll", []() {
+        felspar::io::poll_warden ward;
+        ward.run(read_until_deadline);
+    });
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const ruu = suite.test("read-until-deadline/io_uring", []() {
+        felspar::io::uring_warden ward{5};
+        ward.run(read_until_deadline);
+    });
+#endif
+
+
+}

--- a/test/run/deadline.connect.cpp
+++ b/test/run/deadline.connect.cpp
@@ -19,8 +19,7 @@ namespace {
      * than resetting the timeout for every address.
      */
     felspar::io::warden::task<void> hostname_connect_deadline(
-            felspar::io::warden &ward,
-            char const *const hostname) {
+            felspar::io::warden &ward, char const *const hostname) {
         felspar::test::injected check;
 
         auto const begin = std::chrono::steady_clock::now();
@@ -46,14 +45,12 @@ namespace {
     }
     auto const p = suite.test("poll", []() {
         felspar::io::poll_warden ward;
-        ward.run(
-                hostname_connect_deadline, "felspar.com");
+        ward.run(hostname_connect_deadline, "felspar.com");
     });
 #ifdef FELSPAR_ENABLE_IO_URING
     auto const u = suite.test("uring", []() {
         felspar::io::uring_warden ward{5};
-        ward.run(
-                hostname_connect_deadline, "felspar.com");
+        ward.run(hostname_connect_deadline, "felspar.com");
     });
 #endif
 

--- a/test/run/deadline.connect.cpp
+++ b/test/run/deadline.connect.cpp
@@ -1,0 +1,64 @@
+#include <felspar/io.hpp>
+#include <felspar/test.hpp>
+
+
+using namespace std::literals;
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("deadline/connect");
+
+
+    /**
+     * `connect`-by-hostname tries each address the hostname resolves to in
+     * turn. A single deadline must bound the whole attempt loop, so even though
+     * the host resolves to several addresses that all silently drop the
+     * connection we still time out about one deadline after starting rather
+     * than resetting the timeout for every address.
+     */
+    felspar::io::warden::task<void> hostname_connect_deadline(
+            felspar::io::warden &ward,
+            char const *const hostname,
+            std::source_location const loc) {
+        felspar::test::injected check;
+
+        auto const begin = std::chrono::steady_clock::now();
+        try {
+            /**
+             * Port 808 is silently dropped by the host so the connect hangs
+             * until the deadline rather than being refused outright
+             */
+            co_await felspar::io::connect(ward, hostname, 808, begin + 250ms);
+            check(false) == true;
+        } catch (felspar::io::timeout const &) {
+            check(true) == true;
+        } catch (std::exception const &e) {
+            check.failed(e.what(), loc);
+        } catch (...) { check(false) == true; }
+        auto const elapsed = std::chrono::steady_clock::now() - begin;
+        /**
+         * With a per-address timeout the multiple addresses would push this
+         * well past 2x the deadline; the single shared deadline keeps the whole
+         * operation bounded by roughly one deadline
+         */
+        check(elapsed <= 400ms) == true;
+    }
+    auto const p = suite.test("poll", []() {
+        felspar::io::poll_warden ward;
+        ward.run(
+                hostname_connect_deadline, "felspar.com",
+                std::source_location::current());
+    });
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const u = suite.test("uring", []() {
+        felspar::io::uring_warden ward{5};
+        ward.run(
+                hostname_connect_deadline, "felspar.com",
+                std::source_location::current());
+    });
+#endif
+
+
+}

--- a/test/run/deadline.connect.cpp
+++ b/test/run/deadline.connect.cpp
@@ -20,8 +20,7 @@ namespace {
      */
     felspar::io::warden::task<void> hostname_connect_deadline(
             felspar::io::warden &ward,
-            char const *const hostname,
-            std::source_location const loc) {
+            char const *const hostname) {
         felspar::test::injected check;
 
         auto const begin = std::chrono::steady_clock::now();
@@ -35,7 +34,7 @@ namespace {
         } catch (felspar::io::timeout const &) {
             check(true) == true;
         } catch (std::exception const &e) {
-            check.failed(e.what(), loc);
+            check.failed(e.what());
         } catch (...) { check(false) == true; }
         auto const elapsed = std::chrono::steady_clock::now() - begin;
         /**
@@ -48,15 +47,13 @@ namespace {
     auto const p = suite.test("poll", []() {
         felspar::io::poll_warden ward;
         ward.run(
-                hostname_connect_deadline, "felspar.com",
-                std::source_location::current());
+                hostname_connect_deadline, "felspar.com");
     });
 #ifdef FELSPAR_ENABLE_IO_URING
     auto const u = suite.test("uring", []() {
         felspar::io::uring_warden ward{5};
         ward.run(
-                hostname_connect_deadline, "felspar.com",
-                std::source_location::current());
+                hostname_connect_deadline, "felspar.com");
     });
 #endif
 

--- a/test/run/deadline.connect.cpp
+++ b/test/run/deadline.connect.cpp
@@ -12,11 +12,11 @@ namespace {
 
 
     /**
-     * `connect`-by-hostname tries each address the hostname resolves to in
-     * turn. A single deadline must bound the whole attempt loop, so even though
-     * the host resolves to several addresses that all silently drop the
-     * connection we still time out about one deadline after starting rather
-     * than resetting the timeout for every address.
+     * `connect`-by-hostname must bound its connection attempt by the deadline.
+     * We connect to a single RFC 5737 TEST-NET-1 example address, which is
+     * never routed, so the attempt hangs until the deadline rather than being
+     * refused outright, and we expect a timeout about one deadline after
+     * starting.
      */
     felspar::io::warden::task<void> hostname_connect_deadline(
             felspar::io::warden &ward, char const *const hostname) {
@@ -24,10 +24,6 @@ namespace {
 
         auto const begin = std::chrono::steady_clock::now();
         try {
-            /**
-             * Port 808 is silently dropped by the host so the connect hangs
-             * until the deadline rather than being refused outright
-             */
             co_await felspar::io::connect(ward, hostname, 808, begin + 250ms);
             check(false) == true;
         } catch (felspar::io::timeout const &) {
@@ -37,20 +33,19 @@ namespace {
         } catch (...) { check(false) == true; }
         auto const elapsed = std::chrono::steady_clock::now() - begin;
         /**
-         * With a per-address timeout the multiple addresses would push this
-         * well past 2x the deadline; the single shared deadline keeps the whole
-         * operation bounded by roughly one deadline
+         * The connect must be bounded by the deadline rather than hanging
+         * indefinitely
          */
         check(elapsed <= 400ms) == true;
     }
     auto const p = suite.test("poll", []() {
         felspar::io::poll_warden ward;
-        ward.run(hostname_connect_deadline, "felspar.com");
+        ward.run(hostname_connect_deadline, "192.0.2.1");
     });
 #ifdef FELSPAR_ENABLE_IO_URING
     auto const u = suite.test("uring", []() {
         felspar::io::uring_warden ward{5};
-        ward.run(hostname_connect_deadline, "felspar.com");
+        ward.run(hostname_connect_deadline, "192.0.2.1");
     });
 #endif
 

--- a/test/run/deadline.cpp
+++ b/test/run/deadline.cpp
@@ -1,0 +1,26 @@
+#include <felspar/io/deadline.hpp>
+#include <felspar/test.hpp>
+
+
+using namespace std::literals;
+
+
+namespace {
+
+
+    auto const suite = felspar::testsuite("deadline_from");
+
+
+    auto const dt = suite.test("timeout", [](auto check) {
+        /**
+         * The deadline is computed from a `now()` taken inside `deadline_from`
+         * which is at or after the `before` we capture here, so we allow the
+         * same kind of jitter window the `timers` tests use.
+         */
+        auto const before = std::chrono::steady_clock::now();
+        auto const d = felspar::io::deadline_from(20ms);
+        check(d >= before + 19ms and d <= before + 21ms) == true;
+    });
+
+
+}

--- a/test/run/timers.cpp
+++ b/test/run/timers.cpp
@@ -127,4 +127,77 @@ namespace {
 #endif
 
 
+    felspar::io::warden::task<void> short_accept_deadline(
+            felspar::io::warden &ward,
+            std::uint16_t port,
+            felspar::test::injected check,
+            std::ostream &log) {
+        auto fd = ward.create_socket(AF_INET, SOCK_STREAM, 0);
+        set_reuse_port(fd);
+        bind_to_any_address(fd, port);
+        listen(fd, 64);
+
+        try {
+            co_await ward.accept(fd, std::chrono::steady_clock::now() + 10ms);
+            check(false) == true;
+        } catch (felspar::io::timeout const &) {
+            check(true) == true;
+        } catch (std::exception const &e) {
+            log << e.what() << '\n';
+            check(false) == true;
+        } catch (...) { check(false) == true; }
+    }
+    auto const adp =
+            suite.test("accept-deadline/poll", [](auto check, auto &log) {
+                felspar::io::poll_warden ward;
+                ward.run(short_accept_deadline, 5542, check, std::ref(log));
+            });
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const adu =
+            suite.test("accept-deadline/io_uring", [](auto check, auto &log) {
+                felspar::io::uring_warden ward;
+                ward.run(short_accept_deadline, 5544, check, std::ref(log));
+            });
+#endif
+
+
+    felspar::io::warden::task<void> past_accept_deadline(
+            felspar::io::warden &ward,
+            std::uint16_t port,
+            felspar::test::injected check,
+            std::ostream &log) {
+        auto fd = ward.create_socket(AF_INET, SOCK_STREAM, 0);
+        set_reuse_port(fd);
+        bind_to_any_address(fd, port);
+        listen(fd, 64);
+
+        auto const start = std::chrono::steady_clock::now();
+        try {
+            co_await ward.accept(fd, start - 1ms);
+            check(false) == true;
+        } catch (felspar::io::timeout const &) {
+            check(true) == true;
+        } catch (std::exception const &e) {
+            log << e.what() << '\n';
+            check(false) == true;
+        } catch (...) { check(false) == true; }
+        /// A deadline already in the past must time out essentially
+        /// immediately rather than waiting any real length of time
+        auto const elapsed = std::chrono::steady_clock::now() - start;
+        check(elapsed <= 80ms) == true;
+    }
+    auto const apdp =
+            suite.test("accept-past-deadline/poll", [](auto check, auto &log) {
+                felspar::io::poll_warden ward;
+                ward.run(past_accept_deadline, 5546, check, std::ref(log));
+            });
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const apdu = suite.test(
+            "accept-past-deadline/io_uring", [](auto check, auto &log) {
+                felspar::io::uring_warden ward;
+                ward.run(past_accept_deadline, 5548, check, std::ref(log));
+            });
+#endif
+
+
 }

--- a/test/run/timers.cpp
+++ b/test/run/timers.cpp
@@ -183,8 +183,10 @@ namespace {
             log << e.what() << '\n';
             check(false) == true;
         } catch (...) { check(false) == true; }
-        /// A deadline already in the past must time out essentially
-        /// immediately rather than waiting any real length of time
+        /**
+         * A deadline already in the past must time out essentially immediately
+         * rather than waiting any real length of time
+         */
         auto const elapsed = std::chrono::steady_clock::now() - start;
         check(elapsed <= 80ms) == true;
     }
@@ -202,8 +204,10 @@ namespace {
 #endif
 
 
-    /// Accept a single connection then drain it very slowly so the peer's
-    /// `write_all` is forced to make many partial writes spread out over time
+    /**
+     * Accept a single connection then drain it very slowly so the peer's
+     * `write_all` is forced to make many partial writes spread out over time
+     */
     felspar::io::warden::task<void>
             slow_drain_acceptor(felspar::io::warden &ward, std::uint16_t port) {
         auto fd = ward.create_socket(AF_INET, SOCK_STREAM, 0);
@@ -219,9 +223,11 @@ namespace {
             co_await ward.sleep(5ms);
         }
     }
-    /// A single deadline must bound the whole `write_all` loop rather than
-    /// resetting on each `write_some`, so even though the slow drain lets a few
-    /// partial writes through we still time out close to the deadline
+    /**
+     * A single deadline must bound the whole `write_all` loop rather than
+     * resetting on each `write_some`, so even though the slow drain lets a few
+     * partial writes through we still time out close to the deadline
+     */
     felspar::io::warden::task<void>
             write_all_deadline(felspar::io::warden &ward, std::uint16_t port) {
         felspar::test::injected check;

--- a/test/run/timers.cpp
+++ b/test/run/timers.cpp
@@ -2,6 +2,8 @@
 #include <felspar/coro/eager.hpp>
 #include <felspar/test.hpp>
 
+#include <vector>
+
 
 using namespace std::literals;
 
@@ -197,6 +199,66 @@ namespace {
                 felspar::io::uring_warden ward;
                 ward.run(past_accept_deadline, 5548, check, std::ref(log));
             });
+#endif
+
+
+    /// Accept a single connection then drain it very slowly so the peer's
+    /// `write_all` is forced to make many partial writes spread out over time
+    felspar::io::warden::task<void>
+            slow_drain_acceptor(felspar::io::warden &ward, std::uint16_t port) {
+        auto fd = ward.create_socket(AF_INET, SOCK_STREAM, 0);
+        felspar::posix::set_reuse_port(fd);
+        felspar::posix::bind_to_any_address(fd, port);
+        felspar::posix::listen(fd, 64);
+
+        auto acceptor = felspar::io::accept(ward, fd);
+        auto cnx = co_await acceptor.next();
+        std::array<std::byte, 1 << 10> buffer;
+        for (int i = 0; i < 200; ++i) {
+            co_await felspar::io::read_some(ward, *cnx, buffer);
+            co_await ward.sleep(5ms);
+        }
+    }
+    /// A single deadline must bound the whole `write_all` loop rather than
+    /// resetting on each `write_some`, so even though the slow drain lets a few
+    /// partial writes through we still time out close to the deadline
+    felspar::io::warden::task<void>
+            write_all_deadline(felspar::io::warden &ward, std::uint16_t port) {
+        felspar::test::injected check;
+
+        std::vector<std::byte> buffer(8 << 20);
+        auto fd = ward.create_socket(AF_INET, SOCK_STREAM, 0);
+        sockaddr_in in;
+        in.sin_family = AF_INET;
+        in.sin_port = htons(port);
+        in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        co_await ward.connect(
+                fd, reinterpret_cast<sockaddr const *>(&in), sizeof(in));
+
+        auto const start = std::chrono::steady_clock::now();
+        try {
+            co_await felspar::io::write_all(
+                    ward, fd, std::span<std::byte const>{buffer}, 30ms);
+            check(false) == true;
+        } catch (felspar::io::timeout const &) {
+            check(true) == true;
+        } catch (...) { check(false) == true; }
+        auto const elapsed = std::chrono::steady_clock::now() - start;
+        check(elapsed <= 300ms) == true;
+    }
+    auto const wadp = suite.test("write-all-deadline/poll", []() {
+        felspar::io::poll_warden ward;
+        felspar::io::warden::eager<> co;
+        co.post(slow_drain_acceptor, ward, 5550);
+        ward.run(write_all_deadline, 5550);
+    });
+#ifdef FELSPAR_ENABLE_IO_URING
+    auto const wadu = suite.test("write-all-deadline/io_uring", []() {
+        felspar::io::uring_warden ward;
+        felspar::io::warden::eager<> co;
+        co.post(slow_drain_acceptor, ward, 5552);
+        ward.run(write_all_deadline, 5552);
+    });
 #endif
 
 


### PR DESCRIPTION
This swaps the timeouts with deadlines. Timeout values are still accepted, but they are now converted to a deadline as soon as possible.

This has the most effect on composed operations because it means that something like a read_exact where the data arrives slowly bit by bit will now timeout based on the entire time taken for all I/O instead of using the same time out value for each of the underlying read operations.